### PR TITLE
Build with opensuse-13.1

### DIFF
--- a/package/yast2-services-manager.spec
+++ b/package/yast2-services-manager.spec
@@ -56,7 +56,7 @@ services and targets.
 %prep
 %setup -n yast2-services-manager
 
-%build
+%check
 # opensuse-13.1 does not contain rspec in default repositories
 %if 0%{?suse_version} > 131
 rspec test/*_test.rb


### PR DESCRIPTION
Add conditions to spec file regarding build dependencies - `rubygem-rspec` is not available in opensuse13.1
