### PR TITLE
Rename modules to non-conflicting names. Reason:

### DIFF
--- a/src/clients/default_target_finish.rb
+++ b/src/clients/default_target_finish.rb
@@ -3,12 +3,12 @@ require "installation/minimal_installation"
 module Yast
   import 'Directory'
   import 'Mode'
-  import 'SystemdTarget'
+  import 'ServicesManagerTarget'
 
-  class SystemdTargetFinish < Client
+  class ServicesManagerTargetFinish < Client
 
     module Target
-      include SystemdTargetClass::BaseTargets
+      include ServicesManagerTargetClass::BaseTargets
     end
 
     def initialize
@@ -37,11 +37,11 @@ module Yast
     end
 
     def write
-      SystemdTarget.default_target = Target::MULTIUSER if SystemdTarget.default_target.empty?
-      Builtins.y2milestone "Setting default target to #{SystemdTarget.default_target}"
-      SystemdTarget.save
+      ServicesManagerTarget.default_target = Target::MULTIUSER if ServicesManagerTarget.default_target.empty?
+      Builtins.y2milestone "Setting default target to #{ServicesManagerTarget.default_target}"
+      ServicesManagerTarget.save
     end
   end
-  SystemdTargetFinish.new.call(WFM.Args)
+  ServicesManagerTargetFinish.new.call(WFM.Args)
 end
 

--- a/src/clients/default_target_proposal.rb
+++ b/src/clients/default_target_proposal.rb
@@ -7,13 +7,13 @@ module Yast
   import 'Pkg'
   import "Popup"
   import 'ProductFeatures'
-  import 'SystemdTarget'
+  import 'ServicesManagerTarget'
   import 'Wizard'
 
   class TargetProposal < Client
 
     module Target
-      include SystemdTargetClass::BaseTargets
+      include ServicesManagerTargetClass::BaseTargets
 
       SUPPORTED = [ GRAPHICAL, MULTIUSER ]
     end
@@ -87,8 +87,8 @@ module Yast
             return handle_dialog unless Popup.ContinueCancel(warnings.join "\n")
           end
           Builtins.y2milestone "User selected target '#{selected_target}'"
-          SystemdTarget.default_target = selected_target
-          SystemdTarget.force = true
+          ServicesManagerTarget.default_target = selected_target
+          ServicesManagerTarget.force = true
           :next
         when :cancel
           :cancel
@@ -98,7 +98,7 @@ module Yast
       def generate_target_buttons
         Builtins.y2milestone "Available targets: #{available_targets}"
         radio_buttons = available_targets.map do |target_name|
-          selected = target_name == SystemdTarget.default_target
+          selected = target_name == ServicesManagerTarget.default_target
           Left(RadioButton(Id(target_name), target_name, selected))
         end
         VBox(*radio_buttons)
@@ -167,14 +167,14 @@ module Yast
       def initialize
         textdomain 'services-manager'
         @warnings = []
-        if SystemdTarget.force
+        if ServicesManagerTarget.force
           Builtins.y2milestone(
-            "Default target has been changed before by user manually to '#{SystemdTarget.default_target}'"
+            "Default target has been changed before by user manually to '#{ServicesManagerTarget.default_target}'"
           )
         end
         change_default_target
         detect_warnings(default_target)
-        Builtins.y2milestone("Systemd default target is set to '#{SystemdTarget.default_target}'")
+        Builtins.y2milestone("Systemd default target is set to '#{ServicesManagerTarget.default_target}'")
       end
 
       def create
@@ -193,14 +193,14 @@ module Yast
         # Check if the user forced a particular target before; if he did and the
         # autodetection recommends a different one now, warn the user about this
         # and keep the default target unchanged.
-        if SystemdTarget.force && default_target != SystemdTarget.default_target
+        if ServicesManagerTarget.force && default_target != ServicesManagerTarget.default_target
           warnings << _("The installer is recommending you the default target '%s' ") % default_target
-          warnings << SystemdTarget.proposal_reason
-          self.default_target = SystemdTarget.default_target
+          warnings << ServicesManagerTarget.proposal_reason
+          self.default_target = ServicesManagerTarget.default_target
           return
         end
         Builtins.y2milestone("Setting systemd default target to #{default_target}")
-        SystemdTarget.default_target = default_target
+        ServicesManagerTarget.default_target = default_target
       end
 
       def detect_target
@@ -240,7 +240,7 @@ module Yast
       end
 
       def give_reason message
-        SystemdTarget.proposal_reason = message
+        ServicesManagerTarget.proposal_reason = message
         Builtins.y2milestone("Systemd target detection says: #{message}")
       end
 

--- a/src/clients/services-manager.rb
+++ b/src/clients/services-manager.rb
@@ -126,7 +126,7 @@ class ServicesManagerClient < Yast::Client
   # Redraws the services dialog
   def redraw_services
     UI.OpenDialog(Label(_('Reading services status...')))
-    services = SystemdService.all.collect do |service, attributes|
+    services = ServicesManagerService.all.collect do |service, attributes|
       Item(Id(service),
         service,
         attributes[:enabled] ? _('Enabled') : _('Disabled'),
@@ -140,7 +140,7 @@ class ServicesManagerClient < Yast::Client
   end
 
   def redraw_service(service)
-    enabled = SystemdService.enabled(service)
+    enabled = ServicesManagerService.enabled(service)
 
     UI.ChangeWidget(
       Id(Id::SERVICES_TABLE),
@@ -148,7 +148,7 @@ class ServicesManagerClient < Yast::Client
       (enabled ? _('Enabled') : _('Disabled'))
     )
 
-    running = SystemdService.active(service)
+    running = ServicesManagerService.active(service)
 
     # The current state matches the futural state
     if (enabled == running)
@@ -168,9 +168,9 @@ class ServicesManagerClient < Yast::Client
   end
 
   def redraw_system_targets
-    targets = SystemdTarget.all.collect do |target, target_def|
+    targets = ServicesManagerTarget.all.collect do |target, target_def|
       label = target_def[:description] || target
-      Item(Id(target), label, (target == SystemdTarget.default_target))
+      Item(Id(target), label, (target == ServicesManagerTarget.default_target))
     end
     UI.ChangeWidget(Id(Id::DEFAULT_TARGET), :Items, targets)
   end
@@ -178,13 +178,13 @@ class ServicesManagerClient < Yast::Client
   def handle_dialog
     new_default_target = UI.QueryWidget(Id(Id::DEFAULT_TARGET), :Value)
     Builtins.y2milestone("Setting new default target '#{new_default_target}'")
-    SystemdTarget.default_target = new_default_target
+    ServicesManagerTarget.default_target = new_default_target
   end
 
   # Opens up a popup with details about the currently selected service
   def show_details
     service = UI.QueryWidget(Id(Id::SERVICES_TABLE), :CurrentItem)
-    full_info = SystemdService.status(service)
+    full_info = ServicesManagerService.status(service)
     x_size = full_info.lines.collect{|line| line.size}.sort.last
     y_size = full_info.lines.count
 
@@ -205,9 +205,9 @@ class ServicesManagerClient < Yast::Client
   def switch_service
     service = UI.QueryWidget(Id(Id::SERVICES_TABLE), :CurrentItem)
     Builtins.y2milestone("Setting the service '#{service}' to " +
-      "#{SystemdService.services[service][:active] ? 'inactive' : 'active'}")
+      "#{ServicesManagerService.services[service][:active] ? 'inactive' : 'active'}")
 
-    success = SystemdService.switch(service)
+    success = ServicesManagerService.switch(service)
     redraw_service(service) if success
 
     UI.SetFocus(Id(Id::SERVICES_TABLE))
@@ -219,7 +219,7 @@ class ServicesManagerClient < Yast::Client
   def toggle_service
     service = UI.QueryWidget(Id(Id::SERVICES_TABLE), :CurrentItem)
     Builtins.y2milestone('Toggling service status: %1', service)
-    SystemdService.toggle(service)
+    ServicesManagerService.toggle(service)
 
     redraw_service(service)
     UI.SetFocus(Id(Id::SERVICES_TABLE))

--- a/src/clients/services-manager_auto.rb
+++ b/src/clients/services-manager_auto.rb
@@ -48,10 +48,10 @@ module Yast
       <<-summary
 <h2><%= _('Services Manager') %></h2>
 <p><b><%= _('Default Target') %></b></p>
-<p><%= ERB::Util.html_escape SystemdTarget.export %></p>
+<p><%= ERB::Util.html_escape ServicesManagerTarget.export %></p>
 <p><b><%= _('Enabled Services') %></b></p>
 <ul>
-<% SystemdService.export.each do |service| %>
+<% ServicesManagerService.export.each do |service| %>
   <li><%= ERB::Util.html_escape service %></li>
 <% end %>
 </ul>

--- a/src/clients/services_proposal.rb
+++ b/src/clients/services_proposal.rb
@@ -1,7 +1,7 @@
 require 'services-manager/ui_elements'
 
 module Yast
-  import "SystemdService"
+  import "ServicesManagerService"
   import "Progress"
   import "ProductControl"
   import "ProductFeatures"

--- a/src/modules/services_manager.rb
+++ b/src/modules/services_manager.rb
@@ -1,8 +1,8 @@
 require 'yast'
 
 module Yast
-  import "SystemdTarget"
-  import "SystemdService"
+  import "ServicesManagerTarget"
+  import "ServicesManagerService"
 
   class ServicesManagerClass < Module
     TARGET   = 'default_target'
@@ -17,47 +17,47 @@ module Yast
 
     def export
       {
-        TARGET   => SystemdTarget.export,
-        SERVICES => SystemdService.export
+        TARGET   => ServicesManagerTarget.export,
+        SERVICES => ServicesManagerService.export
       }
     end
 
     def import data
-      SystemdTarget.import  data[TARGET]
-      SystemdService.import data[SERVICES]
+      ServicesManagerTarget.import  data[TARGET]
+      ServicesManagerService.import data[SERVICES]
     end
 
     def reset
-      SystemdTarget.reset
-      SystemdService.reset
+      ServicesManagerTarget.reset
+      ServicesManagerService.reset
     end
 
     def read
-      SystemdTarget.read
-      SystemdService.read
+      ServicesManagerTarget.read
+      ServicesManagerService.read
     end
 
     # Saves the current configuration
     #
     # @return Boolean if successful
     def save
-      target_saved = SystemdTarget.save
-      errors << SystemdTarget.errors
-      services_saved = SystemdService.save
-      errors << SystemdService.errors
+      target_saved = ServicesManagerTarget.save
+      errors << ServicesManagerTarget.errors
+      services_saved = ServicesManagerService.save
+      errors << ServicesManagerService.errors
       !!(target_saved && services_saved)
     end
 
     # Are there any unsaved changes?
     def modified
-      SystemdTarget.modified || SystemdService.modified
+      ServicesManagerTarget.modified || ServicesManagerService.modified
     end
 
     alias_method :modified?, :modified
 
     def modify
-      SystemdTarget.modified = true
-      SystemdService.modified = true
+      ServicesManagerTarget.modified = true
+      ServicesManagerService.modified = true
       true
     end
 

--- a/src/modules/services_manager_service.rb
+++ b/src/modules/services_manager_service.rb
@@ -2,7 +2,7 @@
   import "Service"
   import "Mode"
 
-  class SystemdServiceClass < Module
+  class ServicesManagerServiceClass < Module
     LIST_UNIT_FILES_COMMAND = 'systemctl list-unit-files --type service'
     LIST_UNITS_COMMAND      = 'systemctl list-units --all --type service'
     STATUS_COMMAND          = 'systemctl status'
@@ -415,5 +415,5 @@
     publish({:function => :status,    :type => "string (string)"      })
   end
 
-  SystemdService = SystemdServiceClass.new
+  ServicesManagerService = ServicesManagerServiceClass.new
 end

--- a/src/modules/services_manager_target.rb
+++ b/src/modules/services_manager_target.rb
@@ -3,7 +3,7 @@ require "yast"
 module Yast
   import 'Mode'
 
-  class SystemdTargetClass < Module
+  class ServicesManagerTargetClass < Module
     LIST_UNITS_COMMAND   = 'systemctl list-unit-files --type target'
     LIST_TARGETS_COMMAND = 'systemctl --all --type target'
     COMMAND_OPTIONS      = ' --no-legend --no-pager --no-ask-password '
@@ -204,5 +204,5 @@ module Yast
     publish({:function => :save,           :type => "boolean ()"           })
   end
 
-  SystemdTarget = SystemdTargetClass.new
+  ServicesManagerTarget = ServicesManagerTargetClass.new
 end

--- a/test/services_manager_service_test.rb
+++ b/test/services_manager_service_test.rb
@@ -3,7 +3,7 @@
 require_relative "test_helper"
 
 module Yast
-  describe SystemdService do
+  describe ServicesManagerService do
     attr_reader :service
 
     def stub_services
@@ -14,7 +14,7 @@ module Yast
     end
 
     before do
-      SystemdServiceClass::ServiceLoader.any_instance
+      ServicesManagerServiceClass::ServiceLoader.any_instance
         .stub(:list_unit_files)
         .and_return({
           'stdout'=> "sshd.service     enabled \n"  +
@@ -24,7 +24,7 @@ module Yast
           'stderr' => '',
           'exit'   => 0
         })
-      SystemdServiceClass::ServiceLoader.any_instance
+      ServicesManagerServiceClass::ServiceLoader.any_instance
         .stub(:list_units)
         .and_return({
           'stdout'=>"sshd.service  loaded active   running OpenSSH Daemon\n" +
@@ -34,7 +34,7 @@ module Yast
           'exit'   => 0
         })
 
-      @service = Yast::SystemdServiceClass.new
+      @service = Yast::ServicesManagerServiceClass.new
     end
 
     it "provides a collection of supported services" do

--- a/test/services_manager_target_test.rb
+++ b/test/services_manager_target_test.rb
@@ -3,14 +3,14 @@
 require_relative "test_helper"
 
 module Yast
-  describe Yast::SystemdTarget do
+  describe Yast::ServicesManagerTarget do
     attr_reader :target
 
     before do
-      SystemdTargetClass.any_instance
+      ServicesManagerTargetClass.any_instance
         .stub(:get_default_target_filename)
         .and_return('multi-user.target')
-      SystemdTargetClass.any_instance
+      ServicesManagerTargetClass.any_instance
         .stub(:list_target_units)
         .and_return({
           'stdout' => "multi-user.target         enabled\n" +
@@ -19,7 +19,7 @@ module Yast
           'exit'   => 0
         })
 
-      SystemdTargetClass.any_instance
+      ServicesManagerTargetClass.any_instance
         .stub(:list_targets_details)
         .and_return({
           'stdout' => "multi-user.target  loaded active   active Multi-User System\n" +
@@ -27,10 +27,10 @@ module Yast
           'stderr' => '',
           'exit'   => 0
         })
-      SystemdTargetClass.any_instance.stub(:remove_default_target_symlink).and_return(true)
-      SystemdTargetClass.any_instance.stub(:create_default_target_symlink).and_return(true)
-      SystemdTargetClass.any_instance.stub(:default_target_file)
-      @target = SystemdTargetClass.new
+      ServicesManagerTargetClass.any_instance.stub(:remove_default_target_symlink).and_return(true)
+      ServicesManagerTargetClass.any_instance.stub(:create_default_target_symlink).and_return(true)
+      ServicesManagerTargetClass.any_instance.stub(:default_target_file)
+      @target = ServicesManagerTargetClass.new
     end
 
     it "can set supported target" do

--- a/test/services_manager_test.rb
+++ b/test/services_manager_test.rb
@@ -10,8 +10,8 @@ module Yast
           'a' => {:enabled=>true, :loaded=>true},
           'b' => {:enabled=>false, :loaded=>true}
         }
-        SystemdService.stub(:services).and_return(services)
-        SystemdTarget.stub(:default_target).and_return('some_target')
+        ServicesManagerService.stub(:services).and_return(services)
+        ServicesManagerTarget.stub(:default_target).and_return('some_target')
 
         data = Yast::ServicesManager.export
         expect(data['default_target']).to eq('some_target')
@@ -24,8 +24,8 @@ module Yast
           'default_target' => 'multi-user',
           'services'       => ['x', 'y', 'z']
         }
-        expect(SystemdService).to receive(:import)
-        expect(SystemdTarget).to receive(:import)
+        expect(ServicesManagerService).to receive(:import)
+        expect(ServicesManagerTarget).to receive(:import)
         ServicesManager.import(data)
       end
     end
@@ -34,17 +34,17 @@ module Yast
       it "has available methods for both target and services" do
         public_methods = [ :save, :read, :reset, :modified ]
         public_methods.each do |method|
-          SystemdService.stub(method)
-          SystemdTarget.stub(method)
-          expect(SystemdService).to receive(method)
-          expect(SystemdTarget).to  receive(method)
+          ServicesManagerService.stub(method)
+          ServicesManagerTarget.stub(method)
+          expect(ServicesManagerService).to receive(method)
+          expect(ServicesManagerTarget).to  receive(method)
           ServicesManager.__send__(method)
         end
 
-        SystemdService.stub(:modified=)
-        SystemdTarget.stub(:modified=)
-        expect(SystemdService).to receive(:modified=).with(true)
-        expect(SystemdTarget).to receive(:modified=).with(true)
+        ServicesManagerService.stub(:modified=)
+        ServicesManagerTarget.stub(:modified=)
+        expect(ServicesManagerService).to receive(:modified=).with(true)
+        expect(ServicesManagerTarget).to receive(:modified=).with(true)
         ServicesManager.__send__(:modify)
       end
     end


### PR DESCRIPTION
there were new yast modules added into yast2 package which have
the same names. The naming here was not choosen wisely as it was
not specific enough. The renaming done was:
`SystemdTarget` => `ServicesManagerTarget`
`SystemdService` => `ServicesManagerService`
