### PR TITLE
Don't disable and don't deactivate services not listed in autoyast profile (bnc#868042)

### DIFF
--- a/package/yast2-services-manager.changes
+++ b/package/yast2-services-manager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar 17 09:23:40 UTC 2014 - vmoravec@suse.com
+
+- Do not disable services not listed in autoyast profile 
+  in second stage (bnc#868042)
+- 3.1.10
+
+-------------------------------------------------------------------
 Fri Mar  7 14:15:16 UTC 2014 - vmoravec@suse.com
 
 - Respect the user preference for default target (bnc#867125)

--- a/package/yast2-services-manager.spec
+++ b/package/yast2-services-manager.spec
@@ -24,7 +24,7 @@
 ######################################################################
 
 Name:           yast2-services-manager
-Version:        3.1.9
+Version:        3.1.10
 Release:        0
 BuildArch:      noarch
 

--- a/src/modules/services_manager_service.rb
+++ b/src/modules/services_manager_service.rb
@@ -246,12 +246,8 @@
           enable(service)
         else
           non_existent_services << service
-          Builtins.y2error("Service #{service} doesn't exist on this system")
+          Builtins.y2error("Service '#{service}' doesn't exist on this system")
         end
-      end
-      # The rest will be disabled
-      (services.keys - imported_services).each do |service|
-        disable(service)
       end
       non_existent_services.empty?
     end


### PR DESCRIPTION
The original behaviour affects the installation fatally as it disables and stops all services not listed in the autoyast profile. 
Currently there is no way of finding out from the autoyast profile whether a service should be disabled, we can support only enabling/activating of services.
