### PR TITLE
Marked "runlevel" as not clonable

### DIFF
--- a/package/yast2-services-manager.changes
+++ b/package/yast2-services-manager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul  3 16:32:16 CEST 2014 - locilka@suse.com
+
+- Marked "runlevel" as not clonable, the functionality is there
+  for importing old profiles only (bnc#873604)
+- 3.1.17
+
+-------------------------------------------------------------------
 Wed Jul  2 12:15:17 UTC 2014 - vmoravec@suse.com
 
 - Fix failing tests

--- a/package/yast2-services-manager.spec
+++ b/package/yast2-services-manager.spec
@@ -24,7 +24,7 @@
 ######################################################################
 
 Name:           yast2-services-manager
-Version:        3.1.16
+Version:        3.1.17
 
 Release:        0
 BuildArch:      noarch

--- a/src/desktop/runlevel.desktop
+++ b/src/desktop/runlevel.desktop
@@ -1,4 +1,5 @@
 # This file is needed for legacy support of runlevel autoyast profile
+# and provides only backward compatibility for importing old profiles
 
 [Desktop Entry]
 Type=Application
@@ -14,6 +15,8 @@ X-SuSE-YaST-Group=System
 X-SuSE-YaST-Argument=
 X-SuSE-YaST-RootOnly=true
 X-SuSE-YaST-AutoInst=all
+# bnc#873604 Export is not supported, use services-manager instead
+X-SuSE-YaST-AutoInstClonable=false
 X-SuSE-YaST-Geometry=
 X-SuSE-YaST-SortKey=
 


### PR DESCRIPTION
- the functionality is there for importing old profiles only (bnc#873604)
