### PR TITLE
Fixed detection of a service state

### DIFF
--- a/package/yast2-services-manager.changes
+++ b/package/yast2-services-manager.changes
@@ -2,8 +2,9 @@
 Mon Nov 23 09:50:44 CET 2015 - locilka@suse.com
 
 - Service state 'activating' is considered to be 'active',
-  'deactivating' is 'deactive' and 'reloading' is 'active'
-  (bsc#956043).
+  'deactivating' is 'inactive' and 'reloading' is 'active'.
+  This fixes the second stage of AutoYaST installation getting hung
+  in certain cases as it tried to restart itself (bsc#956043).
 - 3.1.40
 
 -------------------------------------------------------------------

--- a/package/yast2-services-manager.changes
+++ b/package/yast2-services-manager.changes
@@ -2,7 +2,8 @@
 Mon Nov 23 09:50:44 CET 2015 - locilka@suse.com
 
 - Service state 'activating' is considered to be 'active',
-  'deactivating' is 'deactive' (bsc#956043).
+  'deactivating' is 'deactive' and 'reloading' is 'active'
+  (bsc#956043).
 - 3.1.40
 
 -------------------------------------------------------------------

--- a/package/yast2-services-manager.changes
+++ b/package/yast2-services-manager.changes
@@ -1,8 +1,16 @@
 -------------------------------------------------------------------
+Mon Nov 23 09:50:44 CET 2015 - locilka@suse.com
+
+- Service state 'activating' is considered to be 'active',
+  'deactivating' is 'deactive' (bsc#956043).
+- 3.1.40
+
+-------------------------------------------------------------------
 Fri Dec 19 12:14:11 CET 2014 - schubi@suse.de
 
 - AutoYaST: Moved code from autoyast2 package to import function of
   services_manager_target. (bnc#909745)
+- 3.1.39
 
 -------------------------------------------------------------------
 Wed Dec 17 12:18:46 CET 2014 - schubi@suse.de

--- a/package/yast2-services-manager.spec
+++ b/package/yast2-services-manager.spec
@@ -24,7 +24,7 @@
 ######################################################################
 
 Name:           yast2-services-manager
-Version:        3.1.39
+Version:        3.1.40
 Release:        0
 BuildArch:      noarch
 

--- a/src/modules/services_manager_service.rb
+++ b/src/modules/services_manager_service.rb
@@ -27,6 +27,7 @@ module Yast
       LOADED     = 'loaded'
       ACTIVE     = 'active'
       ACTIVATING = 'activating'
+      RELOADING  = 'reloading'
       INACTIVE   = 'inactive'
       ENABLED    = 'enabled'
       DISABLED   = 'disabled'
@@ -85,8 +86,13 @@ module Yast
           service.chomp! SERVICE_SUFFIX
           units[service] = {
             :status => status,
-            # bsc#956043 service can be 'just being activated'
-            :active => (active == Status::ACTIVE || active == Status::ACTIVATING),
+            # bsc#956043 service can be 'just being activated' or 'reloaded'
+            # See https://github.com/systemd/systemd/blob/7152869f0a4a4612022244064cc2b3905b1e3fc7/src/basic/unit-name.c#L844
+            :active => (
+              active == Status::ACTIVE ||
+              active == Status::ACTIVATING ||
+              active == Status::RELOADING
+            ),
             :description => description.join(' ')
           }
         end

--- a/src/modules/services_manager_service.rb
+++ b/src/modules/services_manager_service.rb
@@ -24,11 +24,12 @@ module Yast
     }
 
     module Status
-      LOADED   = 'loaded'
-      ACTIVE   = 'active'
-      INACTIVE = 'inactive'
-      ENABLED  = 'enabled'
-      DISABLED = 'disabled'
+      LOADED     = 'loaded'
+      ACTIVE     = 'active'
+      ACTIVATING = 'activating'
+      INACTIVE   = 'inactive'
+      ENABLED    = 'enabled'
+      DISABLED   = 'disabled'
       SUPPORTED_STATES = [ENABLED, DISABLED]
     end
 
@@ -84,7 +85,8 @@ module Yast
           service.chomp! SERVICE_SUFFIX
           units[service] = {
             :status => status,
-            :active => active == Status::ACTIVE,
+            # bsc#956043 service can be 'just being activated'
+            :active => (active == Status::ACTIVE || active == Status::ACTIVATING),
             :description => description.join(' ')
           }
         end

--- a/test/services_manager_service_test.rb
+++ b/test/services_manager_service_test.rb
@@ -23,7 +23,9 @@ module Yast
           'stdout'=> "sshd.service     enabled \n"  +
                      "postfix.service  disabled\n " +
                      "swap.service     masked  \n"  +
-                     "dbus.service     static  \n",
+                     "dbus.service     static  \n"  +
+                     "xbus.service     enabled \n"  +
+                     "ybus.service     enabled \n",
           'stderr' => '',
           'exit'   => 0
         })
@@ -32,7 +34,9 @@ module Yast
         .and_return({
           'stdout'=>"sshd.service  loaded active   running OpenSSH Daemon\n" +
                     "postfix.service loaded inactive dead    Postfix Mail Agent\n" +
-                    "dbus.service  loaded active   running D-Bus System Message Bus",
+                    "dbus.service  loaded active   running D-Bus System Message Bus\n" +
+                    "xbus.service loaded activating start start YaST2 Second Stage (1)\n" +
+                    "ybus.service loaded deactivating stop start YaST2 Second Stage (2)\n",
           'stderr' => '',
           'exit'   => 0
         })
@@ -164,6 +168,22 @@ module Yast
         service.toggle 'postfix'
         service.save
         expect(service.errors.size).to eq 1
+      end
+    end
+
+    context "when service is in state 'activating'" do
+      it "is considered to be active" do
+        stub_services
+        xbus_service = service.all['xbus']
+        expect(xbus_service[:active]).to eq(true)
+      end
+    end
+
+    context "when service is in state 'deactivating'" do
+      it "is considered to be inactive" do
+        stub_services
+        ybus_service = service.all['ybus']
+        expect(ybus_service[:active]).to eq(false)
       end
     end
   end

--- a/test/services_manager_service_test.rb
+++ b/test/services_manager_service_test.rb
@@ -25,7 +25,8 @@ module Yast
                      "swap.service     masked  \n"  +
                      "dbus.service     static  \n"  +
                      "xbus.service     enabled \n"  +
-                     "ybus.service     enabled \n",
+                     "ybus.service     enabled \n"  +
+                     "zbus.service     enabled \n",
           'stderr' => '',
           'exit'   => 0
         })
@@ -36,7 +37,8 @@ module Yast
                     "postfix.service loaded inactive dead    Postfix Mail Agent\n" +
                     "dbus.service  loaded active   running D-Bus System Message Bus\n" +
                     "xbus.service loaded activating start start YaST2 Second Stage (1)\n" +
-                    "ybus.service loaded deactivating stop start YaST2 Second Stage (2)\n",
+                    "ybus.service loaded deactivating stop start YaST2 Second Stage (2)\n" +
+                    "zbus.service loaded reloading stop start YaST2 Second Stage (3)\n",
           'stderr' => '',
           'exit'   => 0
         })
@@ -184,6 +186,14 @@ module Yast
         stub_services
         ybus_service = service.all['ybus']
         expect(ybus_service[:active]).to eq(false)
+      end
+    end
+
+    context "when service is in state 'reloading'" do
+      it "is considered to be active" do
+        stub_services
+        zbus_service = service.all['zbus']
+        expect(zbus_service[:active]).to eq(true)
       end
     end
   end


### PR DESCRIPTION
- Status 'activating' means it's 'being activated' and thus considered to be 'active' (for the Yast Code purpose), as it will be 'active' after a short while anyway
- Status 'deactivating' is then considered as 'inactive'
- Supported by two simple test cases