### PR TITLE
Port fix to bsc#956917 to openSUSE 13.2

### DIFF
--- a/package/yast2-services-manager.changes
+++ b/package/yast2-services-manager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov 25 00:20:00 CST 2015 - crojasaragonez@hotmail.com
+
+- Closing window with x icon fixed (bsc#956917)
+- 3.1.34.2
+
+-------------------------------------------------------------------
 Wed Dec  3 10:59:13 CET 2014 - locilka@suse.com
 
 - Fixed adjusting service state according to new settings, already

--- a/package/yast2-services-manager.spec
+++ b/package/yast2-services-manager.spec
@@ -24,7 +24,7 @@
 ######################################################################
 
 Name:           yast2-services-manager
-Version:        3.1.34.1
+Version:        3.1.34.2
 
 Release:        0
 BuildArch:      noarch

--- a/src/clients/services-manager.rb
+++ b/src/clients/services-manager.rb
@@ -64,7 +64,7 @@ class ServicesManagerClient < Yast::Client
       Builtins.y2milestone('User returned %1', input)
 
       case input
-        when :abort
+        when :abort, :cancel
           break if Popup::ReallyAbort(ServicesManager.modified?)
         # Default for double-click in the table
         when Id::TOGGLE_ENABLED, Id::SERVICES_TABLE


### PR DESCRIPTION
This bug was originally [reported against openSUSE 13.2](https://github.com/yast/yast-services-manager/issues/103), but the [fix](https://github.com/yast/yast-services-manager/pull/109) was submitted to master. I'm backporting it to openSUSE 13.2. Manually tested.

I guess that we should also submit it to `sle12-sp1-after_release`.