### PR TITLE
[WIP] Systemd service status check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,18 @@ language: bash
 services:
   - docker
 
+notifications:
+  email:
+    on_success: never
+    recipients:
+      - lslezak@suse.cz
+      - mvidner@suse.cz
+
 before_install:
   - docker build -t yast-services-manager-image .
   # list the installed packages (just for easier debugging)
   - docker run --rm -it yast-services-manager-image rpm -qa | sort
 
 script:
-  # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
-  # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
-  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-services-manager-image yast-travis-ruby
+  # scan for changed systemd service statuses
+  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-services-manager-image bash -c "cd devel && ./systemd_status_check.rb"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Jenkins Build](http://img.shields.io/jenkins/s/https/ci.opensuse.org/yast-services-manager-master.svg)](https://ci.opensuse.org/view/Yast/job/yast-services-manager-master/)
 [![Coverage Status](https://coveralls.io/repos/github/yast/yast-services-manager/badge.svg?branch=master)](https://coveralls.io/github/yast/yast-services-manager?branch=master)
 
+Systemd status check: [![Build Status](https://travis-ci.org/yast/yast-services-manager.svg?branch=systemd_states_check)](https://travis-ci.org/yast/yast-services-manager/branches)
+
 
 Systemd target and services configuration library for Yast
 

--- a/devel/expected_states.yml
+++ b/devel/expected_states.yml
@@ -1,0 +1,27 @@
+# This is the list of expected systemd states,
+# used by the ./systemd_status_check.rb script
+---
+unit active states:
+- activating
+- active
+- deactivating
+- failed
+- inactive
+- reloading
+service unit substates:
+- auto-restart
+- dead
+- exited
+- failed
+- final-sigkill
+- final-sigterm
+- reload
+- running
+- start
+- start-post
+- start-pre
+- stop
+- stop-post
+- stop-sigabrt
+- stop-sigkill
+- stop-sigterm

--- a/devel/systemd_status_check.rb
+++ b/devel/systemd_status_check.rb
@@ -1,0 +1,104 @@
+#! /usr/bin/env ruby
+
+# Test whether the systemd defined states have been changed.
+# It it started regurarly from Travis jobs.
+# The expected states are loaded from the expected_states.yml file.
+
+# Rainbow is used by Rubocop, it is already present in the YaST Docker image
+require "English"
+require "rainbow"
+require "shellwords"
+require "tempfile"
+require "yaml"
+
+# run systemctl and get the help about the defined states
+# @return [String]
+def systemd_help
+  help = `systemctl --state=help`
+  raise "Cannot read systemd states help" unless $CHILD_STATUS.success?
+  help
+end
+
+# parses the systemd status help text
+# @param help [String] the input help text
+# @return [Hash<String,Array<String>>]
+def parse_status_help(help)
+  states = {}
+
+  # split the status groups
+  help.split("\n\n").each do |group|
+    lines = group.split("\n")
+    header = lines.shift
+
+    raise "Cannot parse header: #{header}" unless header =~ /Available (.*):/
+    states[Regexp.last_match[1]] = lines.sort
+  end
+
+  states
+end
+
+# read the expected states from the file
+# @param file [String] file name (YAML)
+# @return [Hash<String,Array<String>>] the loaded content
+def read_expected_states(file)
+  YAML.load_file(file)
+end
+
+# print the difference
+# @param name [String] systemd the group name (description)
+# @param expected_states [Array<String>] the expected states
+# @param current_states [Array<String>] the current states
+def print_diff(name, expected_states, current_states)
+  puts Rainbow("Found difference in the #{name.inspect} group:").red
+
+  # the tempfiles are removed at exit automatically
+  expected = Tempfile.new('expected')
+  current = Tempfile.new('actual')
+
+  # add new line at the end to avoid "no newline at the end of the file"
+  # diff message
+  File.write(expected.path, expected_states.join("\n") + "\n")
+  File.write(current.path, current_states.join("\n") + "\n")
+  
+  system("diff --label 'Expected states' --label 'Current states' " \
+    "-u #{Shellwords.escape(expected.path)} #{Shellwords.escape(current.path)}")
+  
+  puts
+end
+
+# compare the current and the expected states
+# prints a diff if a difference is found
+# @return [Boolean] true if the states are equal
+def compare_states(expected, current)
+  compared_groups = expected.map do |name, states|
+
+    # sort the states to accept different order
+    known_states = states.sort
+    current_states = (current[name] || []).sort
+
+    if known_states == current_states
+      puts Rainbow("Found expected states in the #{name.inspect} group").green
+    else
+      print_diff(name, known_states, current_states)
+    end
+
+    known_states == current_states
+  end
+
+  compared_groups.all?
+end
+
+# get the current states
+current = parse_status_help(systemd_help)
+# read the expected states
+expected = read_expected_states(File.expand_path("../expected_states.yml", __FILE__))
+
+# compare them
+equal = compare_states(expected, current)
+
+if equal
+  puts Rainbow("Check OK, no difference found").green
+else
+  puts Rainbow("Check failed!").red
+  exit 1
+end


### PR DESCRIPTION
## Description

- This PR just shows the changes added for checking the systemd states.
- It obsoletes https://github.com/yast/systemd-change-guard/pull/1
- See the [example Travis log](https://travis-ci.org/yast/yast-services-manager/builds/315275621#L732)

### The code will live in a separate branch

- To not mix the normal builds (unit tests) with cron builds (systemd check)
- To have an extra badge in the README to easily spot a failure *[Note: I'll add the same badge into the `master` branch as well.]*
- To notify the specified persons when a failure happens (avoid spamming for the failures in master or in the other branches/PR)
- Travis is [configured](https://travis-ci.org/yast/yast-services-manager/settings) to run the cron job builds once a week for the `systemd_states_check` branch

### Do not merge to `master`, keep this separate branch!!

This is just to discuss the implementation, close the PR after approving and keep the branch. Additionally turn on the GitHub branch protection for it so it's not deleted accidentally.