### PR TITLE
Dynamic service buttons

### DIFF
--- a/src/lib/services-manager/clients/services_manager.rb
+++ b/src/lib/services-manager/clients/services_manager.rb
@@ -134,7 +134,7 @@ module Y2ServicesManager
               show_logs
             when Id::SHOW_DETAILS
               show_details
-            when *START_MODE.keys
+            when *ServicesManagerService.all_start_modes
               set_start_mode(input)
             when :next
               break
@@ -232,7 +232,7 @@ module Y2ServicesManager
       # The log button only is included if YaST Journal is installed.
       def service_buttons(service)
         start_stop_label = ServicesManagerService.active(service) ? _('&Stop') : _('&Start')
-        start_mode_label = start_mode_to_human(ServicesManagerService.start_mode(service))
+        start_mode_label = ServicesManagerService.start_mode_to_human_for(service)
         buttons = [
           PushButton(Id(Id::TOGGLE_RUNNING), start_stop_label),
           HSpacing(1),
@@ -254,9 +254,9 @@ module Y2ServicesManager
       def start_options_for(service)
         start_modes = ServicesManagerService.start_modes(service)
 
-        [:on_boot, :on_demand, :manual].each_with_object([]) do |mode, all|
+        ServicesManagerService.all_start_modes.each_with_object([]) do |mode, all|
           next unless start_modes.include?(mode)
-          all << Item(Id(mode), start_mode_to_human(mode))
+          all << Item(Id(mode), ServicesManagerService.start_mode_to_human(mode))
         end
       end
 
@@ -266,7 +266,7 @@ module Y2ServicesManager
         services = ServicesManagerService.all.collect do |service, attributes|
           Item(Id(service),
             shortened_service_name(service),
-            start_mode_to_human(attributes[:start_mode]),
+            ServicesManagerService.start_mode_to_human_for(service),
             attributes[:active] ? _('Active') : _('Inactive'),
             attributes[:description]
           )
@@ -278,11 +278,10 @@ module Y2ServicesManager
       end
 
       def redraw_service(service)
-        start_mode = ServicesManagerService.start_mode(service)
         UI.ChangeWidget(
           Id(Id::SERVICES_TABLE),
           Cell(service, 1),
-          start_mode_to_human(start_mode)
+          ServicesManagerService.start_mode_to_human_for(service)
         )
 
         enabled = ServicesManagerService.enabled(service)
@@ -437,16 +436,6 @@ module Y2ServicesManager
 
       def current_service
         UI.QueryWidget(Id(Id::SERVICES_TABLE), :CurrentItem)
-      end
-
-      START_MODE = {
-        on_boot:   N_('On Boot'),
-        on_demand: N_('On Demand'),
-        manual:    N_('Manual')
-      }.freeze
-
-      def start_mode_to_human(mode)
-        _(START_MODE[mode])
       end
     end
   end

--- a/src/lib/services-manager/clients/services_manager.rb
+++ b/src/lib/services-manager/clients/services_manager.rb
@@ -217,7 +217,7 @@ module Y2ServicesManager
           Opt(:immediate),
           Header(
             _('Service'),
-            _('Enabled'),
+            _('Start'),
             _('Active'),
             _('Description')
           ),
@@ -254,7 +254,7 @@ module Y2ServicesManager
         services = ServicesManagerService.all.collect do |service, attributes|
           Item(Id(service),
             shortened_service_name(service),
-            attributes[:enabled] ? _('Enabled') : _('Disabled'),
+            start_mode_to_human(attributes[:start_mode]),
             attributes[:active] ? _('Active') : _('Inactive'),
             attributes[:description]
           )
@@ -418,6 +418,16 @@ module Y2ServicesManager
 
       def current_service
         UI.QueryWidget(Id(Id::SERVICES_TABLE), :CurrentItem)
+      end
+
+      START_MODE = {
+        on_boot:   N_('On Boot'),
+        on_demand: N_('On Demand'),
+        manual:    N_('Manual')
+      }.freeze
+
+      def start_mode_to_human(mode)
+        _(START_MODE[mode])
       end
     end
   end

--- a/src/modules/services_manager_service.rb
+++ b/src/modules/services_manager_service.rb
@@ -178,9 +178,7 @@ module Yast
         extract_services_from_units
 
         service_names = services.keys.sort
-        ss = SystemdService.find_many(service_names)
-        # FIXME: define find_may in SystemService
-        ss = ss.compact.map { |s| Yast2::SystemService.new(s) }
+        ss = Yast2::SystemService.find_many(service_names)
         # Rest of settings
         service_names.zip(ss).each do |name, s|
           sh = services[name] # service hash
@@ -438,7 +436,7 @@ module Yast
     end
 
     def set_start_mode!(name)
-      service = Yast::SystemdService.find(name)
+      service = Yast2::SystemService.find(name)
       return false unless service
       service.start_mode = services[name][:start_mode]
     end
@@ -504,7 +502,7 @@ module Yast
       services.each do |service_name, service_attributes|
         next unless service_attributes[:modified]
 
-        service = SystemdService.find(service_name)
+        service = Yast2::SystemService.find(service_name)
         unless service
           log.error "Cannot find service #{service_name}"
           next

--- a/src/modules/services_manager_service.rb
+++ b/src/modules/services_manager_service.rb
@@ -424,6 +424,37 @@ module Yast
       enabled(service) ? disable(service) : enable(service)
     end
 
+    # Sets start_mode for a service (in memory only, use save())
+    #
+    # @param service [String] service name
+    # @param mode    [Symbol] Start mode
+    # @see Yast::SystemdServiceClass::Service#start_modes
+    def set_start_mode(service, mode)
+      exists?(service) do
+        services[service][:start_mode] = mode
+        services[service][:modified] = true
+        self.modified = true
+      end
+    end
+
+    def set_start_mode!(name)
+      service = Yast::SystemdService.find(name)
+      return false unless service
+      service.start_mode = services[name][:start_mode]
+    end
+
+    def start_mode(service)
+      exists?(service) do
+        services[service][:start_mode]
+      end
+    end
+
+    def start_modes(service)
+      exists?(service) do
+        services[service][:start_modes]
+      end
+    end
+
     # Enable or disable the service
     #
     # @param [String] service name
@@ -503,7 +534,7 @@ module Yast
       services_toggled = []
       services.each do |service_name, service_attributes|
         next unless service_attributes[:modified]
-        if toggle! service_name
+        if set_start_mode!(service_name)
           services_toggled << service_name
         else
           change  = enabled(service_name) ? 'enable' : 'disable'

--- a/src/modules/services_manager_service.rb
+++ b/src/modules/services_manager_service.rb
@@ -9,6 +9,7 @@ module Yast
 
   class ServicesManagerServiceClass < Module
     include Yast::Logger
+    extend Yast::I18n
 
     LIST_UNIT_FILES_COMMAND = 'systemctl list-unit-files --type service'
     LIST_UNITS_COMMAND      = 'systemctl list-units --all --type service'
@@ -17,6 +18,12 @@ module Yast
     COMMAND_OPTIONS         = ' --no-legend --no-pager --no-ask-password '
     TERM_OPTIONS            = ' LANG=C TERM=dumb COLUMNS=1024 '
     SERVICE_SUFFIX          = '.service'
+
+    START_MODE = {
+      on_boot:   N_('On Boot'),
+      on_demand: N_('On Demand'),
+      manual:    N_('Manual')
+    }.freeze
 
     # Used by ServicesManagerServiceClass to keep data about an individual service.
     # (Not a real class; documents the structure of a Hash)
@@ -468,6 +475,29 @@ module Yast
     def status(service)
       out = Systemctl.execute("status #{service}#{SERVICE_SUFFIX} 2>&1")
       out['stdout']
+    end
+
+    # Translate start mode for a given service
+    #
+    # @param service [String] service name
+    # @return [String] Translated start mode
+    def start_mode_to_human_for(service)
+      start_mode_to_human(start_mode(service))
+    end
+
+    # List of supported start modes
+    #
+    # @return [Array<String>] Supported start modes
+    def all_start_modes
+      START_MODE.keys
+    end
+
+    # Localized start mode
+    #
+    # @param mode [String] Start mode
+    # @return [String] Localized start mode
+    def start_mode_to_human(mode)
+      _(START_MODE[mode])
     end
 
     private


### PR DESCRIPTION
This PR includes some changes:

* Setting start/stop button label depending on the current status.
* Allow to set the start mode for each service (on demand, on boot or manual).

Manually tested, depends on https://github.com/yast/yast-yast2/pull/751.