### PR TITLE
[WIP] ServicesManagerService uses a placeholder for unknown services

### DIFF
--- a/src/lib/services-manager/system_service_placeholder.rb
+++ b/src/lib/services-manager/system_service_placeholder.rb
@@ -1,0 +1,73 @@
+# encoding: utf-8
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Y2ServicesManager
+  # This class implements a placeholder for real system services. It is used during 1st stage to
+  # hold configuration for those systems that will be available in the installed system (but are
+  # unknown during 1st stage).
+  class SystemServicePlaceholder
+    # @return [String] Service name
+    attr_reader :name
+
+    # Constructor
+    #
+    # @param name [String] Service name
+    def initialize(name)
+      @name
+    end
+
+    # Returns the corresponding systemd service
+    #
+    # @return [Yast::SystemdServiceClass::Service,nil] Systemd service or nil when it is unknown
+    def service
+      @service ||= Yast::SystemdService.find(name)
+    end
+
+    # Returns the service socket if it exists
+    #
+    # @return [Yast::SystemdSocketClass::Socket] Systemd socket or nil when it does not exist
+    def socket
+      service.socket
+    end
+
+    def static?
+      true
+    end
+
+    def start_mode
+      [:boot, :manual]
+    end
+
+    def active
+      false
+    end
+
+    alias_method :active?, :active
+
+    def running?
+      false
+    end
+
+    def description
+      ""
+    end
+  end
+end

--- a/src/modules/services_manager_service.rb
+++ b/src/modules/services_manager_service.rb
@@ -1,6 +1,7 @@
 require "yast"
 require "yast2/system_service"
 require "services-manager/service_loader"
+require "services-manager/system_service_placeholder"
 
 module Yast
   import "Service"
@@ -310,7 +311,8 @@ module Yast
       if Stage.initial && !find(name)
         # We are in inst-sys. So we cannot check for installed services but generate entries
         # for these services if they still not exists.
-        services[name] = Y2ServicesManager::ServiceLoader::DEFAULT_SERVICE_SETTINGS.clone
+        placeholder = Y2ServicesManager::SystemServicePlaceholder.new(name)
+        services[name] = Yast2::SystemService.new(placeholder)
       end
 
       service = find(name)


### PR DESCRIPTION
During 1st stage, while importing configuration, AutoYaST tries to use ServicesManagerService. The
problem is that the services are not known at that point. The old implementation simply [used a hash](https://github.com/yast/yast-services-manager/blob/master/src/modules/services_manager_service.rb#L474)
but the new one uses `SystemService` objects, which rely on `SystemdServiceClass::Service` objects.

Perhaps you have a better idea, but we can:

* Handle those cases were `service.nil?` in `SystemService`. It looks like the simplest but it may make the code of that class dirty.
* Or just use a *placeholder*  which partially implements the `SystemdServiceClass::Service` API.