### PR TITLE
AutoYaST on-demand services activation support

### DIFF
--- a/package/yast2-services-manager.changes
+++ b/package/yast2-services-manager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Aug  8 10:13:46 UTC 2018 - igonzalezsosa@suse.com
+
+- Add support to AutoYaST to set services to be started on demand
+  (related to fate#319428).
+- Improve AutoYaST error handling when configuring services.
+- 4.1.2
+
+-------------------------------------------------------------------
 Mon Aug  6 12:10:23 UTC 2018 - jlopez@suse.com
 
 - Added button to show journal logs (related to fate#319427).

--- a/package/yast2-services-manager.spec
+++ b/package/yast2-services-manager.spec
@@ -32,7 +32,7 @@ BuildRoot:      %{_tmppath}/%{name}-build
 Source0:        %{name}-%{version}.tar.bz2
 
 Requires:       ruby
-# Yast2::SystemService#found? as an array
+# Yast2::SystemService#found?
 Requires:       yast2 >= 4.0.83
 Requires:       yast2-ruby-bindings >= 1.2.0
 # To show service logs
@@ -48,7 +48,7 @@ BuildRequires:  update-desktop-files
 BuildRequires:  yast2-ruby-bindings >= 1.2.0
 # To show service logs
 BuildRequires: 	yast2-journal >= 4.1.1
-# Yast2::SystemService#found? as an array
+# Yast2::SystemService#found?
 BuildRequires:  yast2 >= 4.0.83
 # Support for 'data' directory in rake install task
 BuildRequires:  rubygem(yast-rake) >= 0.1.7

--- a/package/yast2-services-manager.spec
+++ b/package/yast2-services-manager.spec
@@ -24,7 +24,7 @@
 ######################################################################
 
 Name:           yast2-services-manager
-Version:        4.1.1
+Version:        4.1.2
 Release:        0
 BuildArch:      noarch
 
@@ -32,8 +32,8 @@ BuildRoot:      %{_tmppath}/%{name}-build
 Source0:        %{name}-%{version}.tar.bz2
 
 Requires:       ruby
-# Yast2::SystemService#build
-Requires:       yast2 >= 4.0.82
+# Yast2::SystemService#found? as an array
+Requires:       yast2 >= 4.0.83
 Requires:       yast2-ruby-bindings >= 1.2.0
 # To show service logs
 Suggests:	yast2-journal >= 4.1.1
@@ -48,8 +48,8 @@ BuildRequires:  update-desktop-files
 BuildRequires:  yast2-ruby-bindings >= 1.2.0
 # To show service logs
 BuildRequires: 	yast2-journal >= 4.1.1
-# Yast2::SystemService#build
-BuildRequires:  yast2 >= 4.0.82
+# Yast2::SystemService#found? as an array
+BuildRequires:  yast2 >= 4.0.83
 # Support for 'data' directory in rake install task
 BuildRequires:  rubygem(yast-rake) >= 0.1.7
 BuildRequires:  rubygem(rspec)

--- a/src/autoyast_rnc/services-manager.rnc
+++ b/src/autoyast_rnc/services-manager.rnc
@@ -45,10 +45,17 @@ sm_disable =
     service*
   }
 
+sm_on_demand =
+  element on_demand {
+    LIST,
+    service*
+  }
+
 new_services_list =
   element services {
     sm_disable? &
-    sm_enable?
+    sm_enable? &
+    sm_on_demand?
   }
 
 old_services_list =

--- a/src/clients/services-manager_auto.rb
+++ b/src/clients/services-manager_auto.rb
@@ -24,7 +24,7 @@ module Yast
         when 'Import'      then ServicesManager.import(params)
         when 'Export'      then ServicesManager.export
         when 'Read'        then ServicesManager.read
-        when 'Write'       then ServicesManager.save
+        when 'Write'       then write
         when 'Reset'       then ServicesManager.reset
         when 'Packages'    then {}
         when 'GetModified' then ServicesManager.modified?
@@ -34,7 +34,17 @@ module Yast
       end
     end
 
+    # Write services configuration changes
+    #
+    # @return [Boolean] Returns true if the operation was successful; false otherwise.
+    def write
+      return true if ServicesManager.save
+      errors = ServicesManager.errors
+      Yast::Report.LongWarning(errors.join("\n")) unless errors.empty?
+      false
+    end
   end
+
   ServicesManagerAuto.new.call(WFM.Args)
 end
 

--- a/src/clients/services-manager_auto.rb
+++ b/src/clients/services-manager_auto.rb
@@ -1,50 +1,23 @@
-module Yast
-  import 'Wizard'
-  import 'ServicesManager'
+# encoding: utf-8
 
-  class ServicesManagerAuto < Client
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
-    def initialize
-      textdomain 'services-manager'
-    end
-
-    def call args
-      Builtins.y2milestone "Autoyast client called with args #{args}"
-      if args.size == 0
-        Bultins.y2error("missing autoyast command")
-        return
-      end
-
-      function = args.shift
-      params   = args.first
-
-      case function
-        when 'Change'      then WFM.CallFunction('services-manager')
-        when 'Summary'     then ServicesManager.auto_summary
-        when 'Import'      then ServicesManager.import(params)
-        when 'Export'      then ServicesManager.export
-        when 'Read'        then ServicesManager.read
-        when 'Write'       then write
-        when 'Reset'       then ServicesManager.reset
-        when 'Packages'    then {}
-        when 'GetModified' then ServicesManager.modified?
-        when 'SetModified' then ServicesManager.modify
-        else
-          Builtins.y2error("Unknown Autoyast command: #{function}, params: #{params}")
-      end
-    end
-
-    # Write services configuration changes
-    #
-    # @return [Boolean] Returns true if the operation was successful; false otherwise.
-    def write
-      return true if ServicesManager.save
-      errors = ServicesManager.errors
-      Yast::Report.LongWarning(errors.join("\n")) unless errors.empty?
-      false
-    end
-  end
-
-  ServicesManagerAuto.new.call(WFM.Args)
-end
-
+require "services-manager/clients/auto"
+Y2ServicesManager::Clients::Auto.new.run

--- a/src/data/services-manager/autoyast_summary.erb
+++ b/src/data/services-manager/autoyast_summary.erb
@@ -20,6 +20,15 @@
 <% end %>
 </ul>
 
+<% unless services.fetch("on_demand", []).empty? %>
+<p><b><%= _('On Demand') %></b></p>
+<ul>
+<% services.fetch("on_demand", []).each do |service| %>
+  <li><%= ERB::Util.html_escape(service) %></li>
+<% end %>
+</ul>
+<% end %>
+
 <p><b><%= _('Disabled') %></b></p>
 <ul>
 <% services.fetch("disable", []).each do |service| %>

--- a/src/lib/services-manager/clients/auto.rb
+++ b/src/lib/services-manager/clients/auto.rb
@@ -1,0 +1,84 @@
+# encoding: utf-8
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "installation/auto_client"
+Yast.import "ServicesManager"
+
+module Y2ServicesManager
+  module Clients
+    class Auto < ::Installation::AutoClient
+      def initialize
+        textdomain "services-manager"
+      end
+
+      # @see ::Installation::AutoClient#change
+      def change
+        WFM.CallFunction("services-manager")
+      end
+
+      # @see ::Installation::AutoClient#summary
+      def summary
+        Yast::ServicesManager.auto_summary
+      end
+
+      # @see ::Installation::AutoClient#import
+      def import(param)
+        Yast::ServicesManager.import(param)
+      end
+
+      # @see ::Installation::AutoClient#export
+      def export
+        Yast::ServicesManager.export
+      end
+
+      # @see ::Installation::AutoClient#read
+      def read
+        Yast::ServicesManager.read
+      end
+
+      # @see ::Installation::AutoClient#write
+      def write
+        Yast::WFM.CallFunction("services-manager_finish", ["Write"])
+      end
+
+      # @see ::Installation::AutoClient#reset
+      def reset
+        Yast::ServicesManager.reset
+      end
+
+      # @see ::Installation::AutoClient#packages
+      def packages
+        {}
+      end
+
+      # @see ::Installation::AutoClient#modified?
+      def modified?
+        Yast::ServicesManager.modified?
+      end
+
+      # @see ::Installation::AutoClient#modified
+      def modified
+        Yast::ServicesManager.modify
+      end
+    end
+  end
+end

--- a/src/lib/services-manager/clients/services-manager_finish.rb
+++ b/src/lib/services-manager/clients/services-manager_finish.rb
@@ -1,18 +1,27 @@
 require "installation/finish_client"
 
+Yast.import "ServicesManager"
+Yast.import "Report"
+Yast.import "HTML"
+
 module ServicesManager
   module Clients
-    Yast.import "ServicesManagerTarget"
-    Yast.import "ServicesManagerService"
-
     class ServicesManagerFinish < ::Installation::FinishClient
       def title
         textdomain "installation"
         _("Setting default target and system services ...")
       end
 
+      # Writes services configuration changes
+      #
+      # It displays an warning when some error occurs.
+      #
+      # @return [Boolean] Returns true if the operation was successful; false otherwise.
       def write
-        WFM.CallFunction("services-manager_auto", ["Write"])
+        return true if ServicesManager.save
+        errors = ServicesManager.errors
+        Yast::Report.LongWarning(Yast::HTML.List(errors)) unless errors.empty?
+        false
       end
     end
   end

--- a/src/lib/services-manager/clients/services-manager_finish.rb
+++ b/src/lib/services-manager/clients/services-manager_finish.rb
@@ -14,7 +14,7 @@ module ServicesManager
 
       # Writes services configuration changes
       #
-      # It displays an warning when some error occurs.
+      # It displays a warning when some error occurs.
       #
       # @return [Boolean] Returns true if the operation was successful; false otherwise.
       def write

--- a/src/lib/services-manager/clients/services-manager_finish.rb
+++ b/src/lib/services-manager/clients/services-manager_finish.rb
@@ -12,8 +12,7 @@ module ServicesManager
       end
 
       def write
-        ServicesManagerTarget.save
-        ServicesManagerService.save
+        WFM.CallFunction("services-manager_auto", ["Write"])
       end
     end
   end

--- a/src/lib/services-manager/clients/services_manager.rb
+++ b/src/lib/services-manager/clients/services_manager.rb
@@ -23,6 +23,7 @@ require "yast"
 require "services-manager/dialogs/services_manager"
 
 Yast.import "CommandLine"
+Yast.import "Mode"
 
 module Y2ServicesManager
   module Clients
@@ -59,7 +60,11 @@ module Y2ServicesManager
 
       # The log button only is included if YaST Journal is installed
       def run_dialog
-        Dialogs::ServicesManager.new(show_logs_button: journal_loaded?).run
+        Dialogs::ServicesManager.new(
+          show_logs_button: journal_loaded?,
+          show_start_stop_button: !Yast::Mode.config,
+          show_apply_button: !Yast::Mode.config
+        ).run
       end
 
     private

--- a/src/lib/services-manager/dialogs/services_manager.rb
+++ b/src/lib/services-manager/dialogs/services_manager.rb
@@ -161,7 +161,7 @@ module Y2ServicesManager
           HStretch(),
           PushButton(Id(:abort), Opt(:key_F9), Label.CancelButton),
           HSpacing(2),
-          PushButton(Id(:apply), _("&Apply")),
+          Yast::Mode.config ? Empty() : PushButton(Id(:apply), _("&Apply")),
           PushButton(Id(:next), Opt(:key_F10, :default), Label.OKButton)
         )
       end

--- a/src/lib/services-manager/dialogs/services_manager.rb
+++ b/src/lib/services-manager/dialogs/services_manager.rb
@@ -34,6 +34,7 @@ Yast.import "UI"
 Yast.import "Wizard"
 Yast.import "Label"
 Yast.import "Popup"
+Yast.import "Mode"
 
 module Y2ServicesManager
   module Dialogs

--- a/src/lib/services-manager/dialogs/services_manager.rb
+++ b/src/lib/services-manager/dialogs/services_manager.rb
@@ -182,12 +182,17 @@ module Y2ServicesManager
       # @return [Yast::Term]
       def service_buttons
         buttons = [
-          start_stop_button.widget,
-          HSpacing(1),
           start_mode_button.widget,
           HStretch(),
           show_details_button.widget
         ]
+
+        unless Mode.config
+          buttons.unshift(
+            start_stop_button.widget,
+            HSpacing(1),
+          )
+        end
 
         if show_logs_button?
           buttons += [

--- a/src/lib/services-manager/dialogs/services_manager.rb
+++ b/src/lib/services-manager/dialogs/services_manager.rb
@@ -57,10 +57,12 @@ module Y2ServicesManager
       attr_reader :success
       alias_method :success?, :success
 
-      def initialize(show_logs_button: false)
+      def initialize(show_logs_button: false, show_start_stop_button: true, show_apply_button: true)
         textdomain "services-manager"
 
         @show_logs_button = show_logs_button
+        @show_start_stop_button = show_start_stop_button
+        @show_apply_button = show_apply_button
       end
 
       # Runs the dialog and returns if it was successful
@@ -79,6 +81,14 @@ module Y2ServicesManager
       # @return [Boolean] whether the logs button should be shown
       attr_reader :show_logs_button
       alias_method :show_logs_button?, :show_logs_button
+
+      # @return [Boolean] whether the start/stop button should be shown
+      attr_reader :show_start_stop_button
+      alias_method :show_start_stop_button?, :show_start_stop_button
+
+      # @return [Boolean] whether the apply button should be shown
+      attr_reader :show_apply_button
+      alias_method :show_apply_button?, :show_apply_button
 
       # @return [Boolean]
       attr_writer :success
@@ -161,7 +171,7 @@ module Y2ServicesManager
           HStretch(),
           PushButton(Id(:abort), Opt(:key_F9), Label.CancelButton),
           HSpacing(2),
-          Yast::Mode.config ? Empty() : PushButton(Id(:apply), _("&Apply")),
+          show_apply_button? ? PushButton(Id(:apply), _("&Apply")) : Empty(),
           PushButton(Id(:next), Opt(:key_F10, :default), Label.OKButton)
         )
       end
@@ -187,7 +197,7 @@ module Y2ServicesManager
           show_details_button.widget
         ]
 
-        unless Mode.config
+        if show_start_stop_button?
           buttons.unshift(
             start_stop_button.widget,
             HSpacing(1),

--- a/src/lib/services-manager/service_loader.rb
+++ b/src/lib/services-manager/service_loader.rb
@@ -181,8 +181,6 @@ module Y2ServicesManager
       ss.each do |s|
         services[s.name] = s
       end
-    rescue Yast2::SystemService::NotFoundError
-      services.clear
     end
   end
 end

--- a/src/lib/services-manager/services_manager_profile.rb
+++ b/src/lib/services-manager/services_manager_profile.rb
@@ -144,7 +144,7 @@ module Yast
     end
 
     # @return [Hash<String, Symbol>] Map enable/disable to its corresponding start mode.
-    #   The on demand mode is included for convenience.
+    #   The on-demand mode is included for convenience.
     STATUS_TO_START_MODE = {
       ENABLE => :on_boot,
       DISABLE => :manual,
@@ -160,14 +160,14 @@ module Yast
 
     # @return [Hash<String, Symbol>] Map the lists of services that are found in the profile
     #   with their corresponding start modes.
-    LIST_TO_START_MODE = {
+    LIST_NAMES_TO_START_MODE = {
       ENABLE => :on_boot,
       DISABLE => :manual,
       ON_DEMAND => :on_demand
     }.freeze
 
     def load_from_extended_list services
-      LIST_TO_START_MODE.each do |list, mode|
+      LIST_NAMES_TO_START_MODE.each do |list, mode|
         services[list].each do |name|
           self.services << Service.new(name, mode)
         end

--- a/src/lib/services-manager/services_manager_profile.rb
+++ b/src/lib/services-manager/services_manager_profile.rb
@@ -144,7 +144,6 @@ module Yast
     end
 
     # @return [Hash<String, Symbol>] Map enable/disable to its corresponding start mode.
-    #   The on-demand mode is included for convenience.
     STATUS_TO_START_MODE = {
       ENABLE => :on_boot,
       DISABLE => :manual,

--- a/src/lib/services-manager/widgets/base.rb
+++ b/src/lib/services-manager/widgets/base.rb
@@ -44,6 +44,7 @@ module Y2ServicesManager
       #
       # @param id [Symbol] widget id
       def initialize(id: nil)
+        textdomain "services-manager"
         @id = id ? Id(id) : default_id
       end
 

--- a/src/lib/services-manager/widgets/logs_button.rb
+++ b/src/lib/services-manager/widgets/logs_button.rb
@@ -26,9 +26,14 @@ module Y2ServicesManager
   module Widgets
     # Button to show logs of a service
     class LogsButton < Base
-      extend Yast::I18n
 
-      textdomain "services-manager"
+      # Constructor
+      #
+      # @param id [Symbol] widget id
+      def initialize(id: nil)
+        textdomain "services-manager"
+        super
+      end
 
       # Returns the plain libyui widget
       #

--- a/src/lib/services-manager/widgets/show_details_button.rb
+++ b/src/lib/services-manager/widgets/show_details_button.rb
@@ -28,9 +28,14 @@ module Y2ServicesManager
   module Widgets
     # Button to show details about a service
     class ShowDetailsButton < Base
-      extend Yast::I18n
 
-      textdomain "services-manager"
+      # Constructor
+      #
+      # @param id [Symbol] widget id
+      def initialize(id: nil)
+        textdomain "services-manager"
+        super
+      end
 
       # Returns the plain libyui widget
       #

--- a/src/lib/services-manager/widgets/start_mode_button.rb
+++ b/src/lib/services-manager/widgets/start_mode_button.rb
@@ -28,6 +28,7 @@ module Y2ServicesManager
   module Widgets
     # Menu button to set the start mode of a service
     class StartModeButton < Base
+
       # Constructor
       #
       # @param service_name [String] name of a service

--- a/src/lib/services-manager/widgets/target_selector.rb
+++ b/src/lib/services-manager/widgets/target_selector.rb
@@ -28,9 +28,14 @@ module Y2ServicesManager
   module Widgets
     # Widget to select a systemd target
     class TargetSelector < Base
-      extend Yast::I18n
 
-      textdomain "services-manager"
+      # Constructor
+      #
+      # @param id [Symbol] widget id
+      def initialize(id: nil)
+        textdomain "services-manager"
+        super
+      end
 
       # Returns the plain libyui widget
       #

--- a/src/modules/services_manager_service.rb
+++ b/src/modules/services_manager_service.rb
@@ -185,7 +185,8 @@ module Yast
       on_demand_srvs = exportable_on_demand_services
       disabled_srvs = exportable_disabled_services | ServicesProposal.disabled_services
 
-      log.info "Export: enabled services: #{on_boot_srvs}, disabled services: #{disabled_srvs}"
+      log.info "Exported services: on boot: #{on_boot_srvs}; on-demand: #{on_demand_srvs}; " \
+        "disabled: #{disabled_srvs}"
 
       { "enable" => on_boot_srvs, "on_demand" => on_demand_srvs, "disable" => disabled_srvs }
     end

--- a/src/modules/services_manager_service.rb
+++ b/src/modules/services_manager_service.rb
@@ -386,7 +386,7 @@ module Yast
         # %{change} is replaced by the target action (i.e., "start" or "stop"),
         # %{service} is a service name (e.g., "cups"), and %{status} is the current
         # service status (i.e., "running" or "not running").
-        _("Could not %{change} %{service} which is currently %{status}."),
+        _("Could not %{change} '%{service}' which is currently %{status}."),
         change:  change,
         service: service.name,
         status:  status
@@ -408,7 +408,7 @@ module Yast
         # TRANSLATORS: Error message when it was not possible to change the start
         # mode of a service. %{service} is replaced by a service name (e.g., "cups")
         # and %{change} is the target start mode (e.g., "on boot").
-        _("Could not set %{service} to be started %{change}."),
+        _("Could not set '%{service}' to be started %{change}."),
         service: service.name,
         change:  _(START_MODE_TEXT[service.start_mode])
       )
@@ -419,7 +419,7 @@ module Yast
     # @return [String] Error message
     def not_found_error_message_for(service)
       format(
-        _("Service %{service} was not found."),
+        _("Service '%{service}' was not found."),
         service: service.name
       )
     end

--- a/src/modules/services_manager_service.rb
+++ b/src/modules/services_manager_service.rb
@@ -351,7 +351,7 @@ module Yast
     # @param service [String] Service name
     # @return [Array<String>] List of error messages
     def error_messages_for(service)
-      service.errors.keys.map do |key|
+      service.errors.map do |key|
         send("#{key}_error_message_for", service)
       end
     end
@@ -395,6 +395,16 @@ module Yast
         _("Could not set %{service} to be started %{change}."),
         service: service.name,
         change:  _(START_MODE_TEXT[service.start_mode])
+      )
+    end
+
+    # Returns a error message when the underlying service is not found
+    #
+    # @return [String] Error message
+    def not_found_error_message_for(service)
+      format(
+        _("Service %{service} was not found."),
+        service: service.name
       )
     end
 

--- a/src/modules/services_manager_service.rb
+++ b/src/modules/services_manager_service.rb
@@ -205,9 +205,9 @@ module Yast
 
       known_services, unknown_services = profile.services.partition { |service| exists?(service.name) }
 
-      enable_or_disable(known_services)
+      result = enable_or_disable(known_services)
 
-      if unknown_services.empty?
+      if unknown_services.empty? && result
         true
       else
         log.error("Services #{unknown_services.inspect} don't exist on this system")
@@ -426,11 +426,14 @@ module Yast
     #
     # @param services [Array<Service>] services to be enabled or disabled
     def enable_or_disable(services)
+      result = true
       services.each do |service|
         set_start_mode(service.name, service.start_mode)
       rescue ArgumentError => e
+        result = false
         log.error("Invalid start mode '#{service.start_mode}' for service '#{service.name}'")
       end
+      result
     end
 
     # Refresh the services information

--- a/src/modules/services_manager_service.rb
+++ b/src/modules/services_manager_service.rb
@@ -424,17 +424,12 @@ module Yast
     #
     # @see #import
     #
-    # @param services [Array<SystemService>] services to be enabled or disabled
+    # @param services [Array<Service>] services to be enabled or disabled
     def enable_or_disable(services)
       services.each do |service|
-        case service.status
-        when "enable"
-          enable(service.name)
-        when "disable"
-          disable(service.name)
-        else
-          log.error("Unknown status '#{service.status}' for service '#{service.name}'")
-        end
+        set_start_mode(service.name, service.start_mode)
+      rescue ArgumentError => e
+        log.error("Invalid start mode '#{service.start_mode}' for service '#{service.name}'")
       end
     end
 

--- a/test/clients/auto_test.rb
+++ b/test/clients/auto_test.rb
@@ -1,0 +1,132 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "services-manager/clients/auto"
+
+describe Y2ServicesManager::Clients::Auto do
+  subject(:client) { Y2ServicesManager::Clients::Auto.new }
+
+  describe "change" do
+    before do
+      allow(Yast::WFM).to receive(:CallFunction).with("services-manager")
+        .and_return(true)
+    end
+
+    it "runs services-manager client" do
+      expect(Yast::WFM).to receive(:CallFunction).with("services-manager")
+      client.change
+    end
+
+    it "returns the value from the services-manager client" do
+      expect(client.change).to eq(true)
+    end
+  end
+
+  describe "#summary" do
+    before do
+      allow(Yast::ServicesManager).to receive(:auto_summary)
+        .and_return("Services List")
+    end
+
+    it "returns the AutoYaST summary" do
+      expect(client.summary).to eq("Services List")
+    end
+  end
+
+  describe "#import" do
+    let(:profile) { { "default-target" => "graphical" } }
+
+    it "imports the profile" do
+      expect(Yast::ServicesManager).to receive(:import).with(profile)
+      client.import(profile)
+    end
+  end
+
+  describe "#export" do
+    let(:profile) { { "default-target" => "graphical" } }
+
+    before do
+      allow(Yast::ServicesManager).to receive(:export).and_return(profile)
+    end
+
+    it "exports the services information for the AutoYaST profile" do
+      expect(client.export).to eq(profile)
+    end
+  end
+
+  describe "#read" do
+    it "runs system services information" do
+      expect(Yast::ServicesManager).to receive(:read)
+      client.read
+    end
+  end
+
+  describe "#write" do
+    before do
+      allow(Yast::WFM).to receive(:CallFunction).and_return(true)
+    end
+
+    it "runs services manager finish client" do
+      expect(Yast::WFM).to receive(:CallFunction).with("services-manager_finish", ["Write"])
+      client.write
+    end
+
+    it "returns the value from the finish client" do
+      expect(client.write).to eq(true)
+    end
+  end
+
+  describe "#reset" do
+    it "resets the services information" do
+      expect(Yast::ServicesManager).to receive(:reset)
+      client.reset
+    end
+  end
+
+  describe "#packages" do
+    it "returns an empty hash (no packages to install)" do
+      expect(client.packages).to eq({})
+    end
+  end
+
+  describe "#modified?" do
+    before do
+      allow(Yast::ServicesManager).to receive(:modified?).and_return(modified?)
+    end
+
+    context "when the services information was modified" do
+      let(:modified?) { true }
+
+      it "returns true" do
+        expect(client.modified?).to eq(true)
+      end
+    end
+
+    context "when the services information was modified" do
+      let(:modified?) { false }
+
+      it "returns false" do
+        expect(client.modified?).to eq(false)
+      end
+    end
+  end
+end

--- a/test/clients/auto_test.rb
+++ b/test/clients/auto_test.rb
@@ -25,7 +25,7 @@ require "services-manager/clients/auto"
 describe Y2ServicesManager::Clients::Auto do
   subject(:client) { Y2ServicesManager::Clients::Auto.new }
 
-  describe "change" do
+  describe "#change" do
     before do
       allow(Yast::WFM).to receive(:CallFunction).with("services-manager")
         .and_return(true)

--- a/test/clients/services_manager_test.rb
+++ b/test/clients/services_manager_test.rb
@@ -49,7 +49,7 @@ describe Y2ServicesManager::Clients::ServicesManager do
 
       it "runs the dialog with a button to show the logs" do
         expect(Y2ServicesManager::Dialogs::ServicesManager).to receive(:new)
-          .with(show_logs_button: true).and_return(dialog)
+          .with(hash_including(show_logs_button: true)).and_return(dialog)
 
         subject.run
       end
@@ -62,8 +62,26 @@ describe Y2ServicesManager::Clients::ServicesManager do
 
       it "runs the dialog without a button to show the logs" do
         expect(Y2ServicesManager::Dialogs::ServicesManager).to receive(:new)
-          .with(show_logs_button: false).and_return(dialog)
+          .with(hash_including(show_logs_button: false)).and_return(dialog)
 
+        subject.run
+      end
+    end
+
+    context "when running in config mode" do
+      before do
+        allow(Yast::Mode).to receive(:config).and_return(true)
+      end
+
+      it "runs the dialog without a button to start/stop services" do
+        expect(Y2ServicesManager::Dialogs::ServicesManager).to receive(:new)
+          .with(hash_including(show_start_stop_button: false)).and_return(dialog)
+        subject.run
+      end
+
+      it "runs the dialog without a button to apply changes" do
+        expect(Y2ServicesManager::Dialogs::ServicesManager).to receive(:new)
+          .with(hash_including(show_apply_button: false)).and_return(dialog)
         subject.run
       end
     end

--- a/test/dialogs/services_manager_test.rb
+++ b/test/dialogs/services_manager_test.rb
@@ -138,6 +138,56 @@ describe Y2ServicesManager::Dialogs::ServicesManager do
       end
     end
 
+    context "when start/stop button should be shown" do
+      subject { described_class.new(show_start_stop_button: true) }
+
+      let(:user_input) { [:cancel] }
+
+      it "offers a button to start/stop services" do
+        expect_refresh_buttons { |buttons| contain_button?(buttons, "&Stop") }
+        subject.run
+      end
+    end
+
+    context "when start/stop button should not be shown" do
+      subject { described_class.new(show_start_stop_button: false) }
+
+      let(:user_input) { [:cancel] }
+
+      it "does not offer a button to start/stop services" do
+        expect_refresh_buttons { |buttons| !contain_button?(buttons, "&Stop") }
+        subject.run
+      end
+    end
+
+    context "when apply button should be shown" do
+      subject { described_class.new(show_apply_button: true) }
+
+      let(:user_input) { [:cancel] }
+
+      it "offers a button to apply changes" do
+        expect(Yast::Wizard).to receive(:GenericDialog) do |content|
+          expect(contain_button?(content, "&Apply")).to eq(true)
+        end
+
+        subject.run
+      end
+    end
+
+    context "when apply button should not be shown" do
+      subject { described_class.new(show_apply_button: false) }
+
+      let(:user_input) { [:cancel] }
+
+      it "does not offer a button to apply changes" do
+        expect(Yast::Wizard).to receive(:GenericDialog) do |content|
+          expect(contain_button?(content, "&Apply")).to eq(false)
+        end
+
+        subject.run
+      end
+    end
+
     context "when user selects 'Cancel' button" do
       let(:user_input) { [:cancel] }
 

--- a/test/services-manager_finish_test.rb
+++ b/test/services-manager_finish_test.rb
@@ -5,6 +5,8 @@ require_relative "./test_helper"
 require "services-manager/clients/services-manager_finish.rb"
 
 describe ::ServicesManager::Clients::ServicesManagerFinish do
+  subject(:client) { described_class.new }
+
   describe "#title" do
     it "returns string with title" do
       expect(subject.title).to be_a ::String
@@ -12,11 +14,35 @@ describe ::ServicesManager::Clients::ServicesManagerFinish do
   end
 
   describe "#write" do
-    it "writes installation services and default target" do
-      expect(::Yast::ServicesManagerTarget).to receive(:save)
-      expect(::Yast::ServicesManagerService).to receive(:save)
+    let(:success) { true }
+    let(:errors) { [] }
 
-      subject.write
+    before do
+      allow(Yast::ServicesManager).to receive(:save).and_return(success)
+      allow(Yast::ServicesManager).to receive(:errors).and_return(errors)
+    end
+
+    it "returns true" do
+      expect(client.write).to eq(true)
+    end
+
+    context "when some error ocurred" do
+      let(:success) { false }
+      let(:errors) { ["Error #1", "Error #2"] }
+
+      before do
+        allow(Yast::Report).to receive(:LongWarning)
+      end
+
+      it "displays a warning" do
+        expect(Yast::Report).to receive(:LongWarning)
+          .with("<ul><li>Error #1</li><li>Error #2</li></ul>")
+        client.write
+      end
+
+      it "returns false" do
+        expect(client.write).to eq(false)
+      end
     end
   end
 end

--- a/test/services_manager_profile_test.rb
+++ b/test/services_manager_profile_test.rb
@@ -6,11 +6,11 @@ require 'services-manager/services_manager_profile'
 
 module Yast
   describe ServicesManagerProfile do
-    attr_reader :profile, :autoyast_profile
+    let(:profile) { ServicesManagerProfile.new(autoyast_profile) }
 
     context "legacy runlevel autoyast profile" do
-      before do
-        @autoyast_profile = {
+      let(:autoyast_profile) do
+        {
           'default'  => '3',
           'services' => [
             {
@@ -35,7 +35,6 @@ module Yast
             },
           ]
         }
-        @profile = ServicesManagerProfile.new(autoyast_profile)
       end
 
       it "returns profile object with services collection" do
@@ -73,12 +72,11 @@ module Yast
     end
 
     context "simplified services profile" do
-      before do
-        @autoyast_profile = {
+      let(:autoyast_profile) do
+        {
           'default_target'=>'graphical',
           'services' => [ 'sshd', 'iscsi' ]
         }
-        @profile = ServicesManagerProfile.new(autoyast_profile)
       end
 
       it "returns profile object that provides services collection" do
@@ -113,7 +111,6 @@ module Yast
           }
         }
       end
-      let(:profile) { ServicesManagerProfile.new(autoyast_profile) }
 
       describe "#autoyast_profile" do
         it "returns the original data from autoyast" do
@@ -173,10 +170,7 @@ module Yast
     end
 
     context "missing services and target entries in profile" do
-      before do
-        @autoyast_profile = {}
-        @profile = ServicesManagerProfile.new(autoyast_profile)
-      end
+      let(:autoyast_profile) { {} }
 
       it "provides not target information" do
         expect(profile.target).to be_nil
@@ -188,13 +182,12 @@ module Yast
     end
 
     context "wrong services entries in profile" do
-      before do
-        @autoyast_profile = {
+      let(:autoyast_profile) do
+        {
           'services' => {
             'wrong_entry' => ['wrong_entry']
           }
         }
-        @profile = ServicesManagerProfile.new(autoyast_profile)
       end
 
       it "provides empty list of services" do

--- a/test/services_manager_profile_test.rb
+++ b/test/services_manager_profile_test.rb
@@ -23,6 +23,16 @@ module Yast
               'service_status' => 'disable',
               'service_start'  => '5'
             },
+            {
+              'service_name' => 'YaST2-Second-Stage',
+              'service_status' => 'disable',
+              'service_start'  => '5'
+            },
+            {
+              'service_name' => 'YaST2-Firstboot',
+              'service_status' => 'disable',
+              'service_start'  => '5'
+            },
           ]
         }
         @profile = ServicesManagerProfile.new(autoyast_profile)
@@ -37,16 +47,23 @@ module Yast
         expect(profile.autoyast_profile).to equal(autoyast_profile)
       end
 
-      it "provides collection of services to be enabled" do
+      it "provides collection of services to be started on boot" do
         service = profile.services.find {|s| s.name == 'sshd'}
         expect(service).not_to be_nil
-        expect(service.status).to eq('enable')
+        expect(service.start_mode).to eq(:on_boot)
       end
 
       it "provides collection of services to be disabled" do
         service = profile.services.find {|s| s.name == 'libvirt'}
         expect(service).not_to be_nil
-        expect(service.status).to eq('disable')
+        expect(service.start_mode).to eq(:manual)
+      end
+
+      YAST_SERVICES = ["YaST2-Firstboot", "YaST2-Second-Stage"]
+
+      it "ignores YaST services" do
+        service_names = profile.services.map(&:name)
+        expect(service_names).to_not include(*YAST_SERVICES)
       end
 
       it "provides default target" do
@@ -73,10 +90,10 @@ module Yast
         expect(profile.autoyast_profile).to equal(autoyast_profile)
       end
 
-      it "provides collection of services to be enabled" do
+      it "provides collection of services to be started on boot" do
         service = profile.services.find {|s| s.name == 'sshd'}
         expect(service).not_to be_nil
-        expect(service.status).to eq('enable')
+        expect(service.start_mode).to eq(:on_boot)
       end
 
       it "provides default target" do
@@ -90,8 +107,9 @@ module Yast
         @autoyast_profile = {
           'default_target' => 'multi-user',
           'services' => {
-            'enable'  => ['sshd',  'iscsi'  ],
-            'disable' => ['nginx', 'libvirt']
+            'enable'    => ['sshd',  'iscsi'  ],
+            'disable'   => ['nginx', 'libvirt'],
+            'on_demand' => ['cups']
           }
         }
         @profile = ServicesManagerProfile.new(autoyast_profile)
@@ -99,7 +117,7 @@ module Yast
 
       it "returns profile object that provides services collection" do
         expect(profile.services).not_to be_empty
-        expect(profile.services.size).to eq(4)
+        expect(profile.services.size).to eq(5)
       end
 
       it "provides the original data from autoyast" do
@@ -109,13 +127,19 @@ module Yast
       it "provides collection of services to be disabled" do
         service = profile.services.find {|s| s.name == 'nginx'}
         expect(service).not_to be_nil
-        expect(service.status).to eq('disable')
+        expect(service.start_mode).to eq(:manual)
       end
 
-      it "provides collection of services to be enabled" do
+      it "provides collection of services to be started on boot" do
         service = profile.services.find {|s| s.name == 'sshd'}
         expect(service).not_to be_nil
-        expect(service.status).to eq('enable')
+        expect(service.start_mode).to eq(:on_boot)
+      end
+
+      it "provides collection of services to be started on demand" do
+        service = profile.services.find {|s| s.name == 'cups'}
+        expect(service).not_to be_nil
+        expect(service.start_mode).to eq(:on_demand)
       end
 
       it "provides default target" do

--- a/test/services_manager_service_test.rb
+++ b/test/services_manager_service_test.rb
@@ -367,13 +367,26 @@ describe Yast::ServicesManagerServiceClass do
         allow(dbus).to receive(:static?).and_return(false)
       end
 
-      context "and is enabled" do
+      context "and is set to be started on boot" do
         before do
           allow(dbus).to receive(:start_mode).and_return(:on_boot)
         end
 
         it "exports the service as enabled" do
           expect(exported_services["enable"]).to include("dbus")
+        end
+      end
+
+      context "and is set to be started on demand" do
+        before do
+          allow(dbus).to receive(:start_mode).and_return(:on_demand)
+        end
+
+        it "exports the services to be started on demand" do
+          exported = subject.export
+          expect(exported["on_demand"]).to include("dbus")
+          expect(exported["enable"]).to_not include("dbus")
+          expect(exported["disable"]).to_not include("dbus")
         end
       end
 
@@ -404,13 +417,25 @@ describe Yast::ServicesManagerServiceClass do
         end
       end
 
-      context "and was enabled" do
+      context "and was set to be started on boot" do
         before do
           allow(cups).to receive(:start_mode).and_return(:on_boot)
         end
 
         it "exports the service as enable" do
           expect(exported_services["enable"]).to include("cups")
+          expect(exported_services["disable"]).to_not include("cups")
+        end
+      end
+
+      context "and was set to be started on demand" do
+        before do
+          allow(cups).to receive(:start_mode).and_return(:on_demand)
+        end
+
+        it "exports the service to be started on demand" do
+          expect(exported_services["on_demand"]).to include("cups")
+          expect(exported_services["enable"]).to_not include("cups")
           expect(exported_services["disable"]).to_not include("cups")
         end
       end
@@ -564,7 +589,6 @@ describe Yast::ServicesManagerServiceClass do
       expect(cups).to_not receive(:refresh)
       subject.save
     end
-
 
     context "when a service registers an error" do
       before do

--- a/test/services_manager_service_test.rb
+++ b/test/services_manager_service_test.rb
@@ -533,12 +533,13 @@ describe Yast::ServicesManagerServiceClass do
       end
 
       it "logs an error" do
+        allow(subject.log).to receive(:error)
         expect(subject.log).to receive(:error).with(/Invalid/)
         subject.import(profile)
       end
 
-      it "returns true" do
-        expect(subject.import(profile)).to eq(true)
+      it "returns false" do
+        expect(subject.import(profile)).to eq(false)
       end
     end
   end

--- a/test/services_manager_service_test.rb
+++ b/test/services_manager_service_test.rb
@@ -607,9 +607,9 @@ describe Yast::ServicesManagerServiceClass do
     it "returns the list of service errors" do
       subject.save
       expect(subject.errors).to contain_exactly(
-        "Service cups was not found.",
-        "Could not start dbus which is currently running.",
-        "Could not set dbus to be started on boot."
+        "Service 'cups' was not found.",
+        "Could not start 'dbus' which is currently running.",
+        "Could not set 'dbus' to be started on boot."
       )
     end
 

--- a/test/services_manager_service_test.rb
+++ b/test/services_manager_service_test.rb
@@ -598,14 +598,15 @@ describe Yast::ServicesManagerServiceClass do
 
   describe "#errors" do
     before do
-      allow(dbus).to receive(:errors).and_return({:active => true})
-      allow(cups).to receive(:errors).and_return({:start_mode => :manual})
+      allow(dbus).to receive(:errors).and_return([:active, :start_mode, :not_found])
+      allow(dbus).to receive(:start_mode).and_return(:on_boot)
     end
 
     it "returns the list of service errors" do
       expect(subject.errors).to eq([
-        "Could not set cups to be started on boot.",
-        "Could not start dbus which is currently running."
+        "Could not start dbus which is currently running.",
+        "Could not set dbus to be started on boot.",
+        "Service dbus was not found."
       ])
     end
   end

--- a/test/services_manager_test.rb
+++ b/test/services_manager_test.rb
@@ -176,27 +176,6 @@ module Yast
         end
       end
 
-      context "when using AutoYast profile in the current format" do
-        it "imports data for systemd target and services" do
-          data = {
-            'default_target' => 'multi-user',
-            'services' => {
-              'enable'  => ['x', 'y', 'z', "YaST2-Firstboot", "YaST2-Second-Stage"],
-              'disable' => ['d', 'e', 'f'],
-            },
-          }
-          expect(ServicesManagerService).to receive(:exists?).with(/^[xyzdef]$/).at_least(:once).and_return(true)
-          expect(ServicesManagerService).to receive(:enable).with(/^[xyz]$/).exactly(3).times.and_return(true)
-          expect(ServicesManagerService).not_to receive(:enable).with("YaST2-Second-Stage")
-          expect(ServicesManagerService).not_to receive(:enable).with("YaST2-Firstboot")
-          expect(ServicesManagerService).to receive(:disable).with(/^[def]$/).exactly(3).times.and_return(true)
-
-          expect(ServicesManagerService).to receive(:import).and_call_original
-          expect(ServicesManagerTarget).to receive(:import).and_call_original
-          expect(ServicesManager.import(data)).to eq(true)
-        end
-      end
-
       context "when configuration hasn't been cloned/modified" do
         it "returns information that it hasn't been configured yet" do
           expect(ServicesManager).to receive(:modified?).and_return(false)

--- a/test/services_manager_test.rb
+++ b/test/services_manager_test.rb
@@ -92,10 +92,10 @@ module Yast
           }
 
           expect(ServicesManagerService).to receive(:exists?).with(/^s[abc]$/).at_least(:once).and_return(true)
-          expect(ServicesManagerService).to receive(:enable).with(/^s[ab]$/).twice.and_return(true)
-          expect(ServicesManagerService).not_to receive(:enable).with("YaST2-Second-Stage")
-          expect(ServicesManagerService).not_to receive(:enable).with("YaST2-Firstboot")
-          expect(ServicesManagerService).to receive(:disable).with(/^sc$/).once.and_return(true)
+          expect(ServicesManagerService).to receive(:set_start_mode)
+            .with(/^s[ab]$/, :on_boot).twice.and_return(true)
+          expect(ServicesManagerService).to receive(:set_start_mode)
+            .with("sc", :manual).and_return(true)
 
           expect(ServicesManagerService).to receive(:import).and_call_original
           expect(ServicesManagerTarget).to receive(:import).and_call_original

--- a/test/support/services_manager_helpers.rb
+++ b/test/support/services_manager_helpers.rb
@@ -95,6 +95,7 @@ module Yast
           description:  service_specs[:description],
           keywords:     service_specs[:keywords],
           changed?:     service_specs[:changed] || false,
+          found?:       service_specs[:found] || true,
           errors:       service_specs[:errors] || []
         )
 


### PR DESCRIPTION
When importing a profile, AutoYaST supports [three different formats](https://github.com/yast/yast-services-manager/blob/9510570de856caca3639855df28aef46969318d7/src/lib/services-manager/services_manager_profile.rb#L5-L55). The first of them is the current (and documented) one. Second and third are just legacy formats that should not be used anymore.

This PR adds support for on-demand services activation (sockets). To keep the new format backward compatible, the proposal is to add a new list of services (`on_demand`):

```xml
<services>
  <enable config:type="list">
    <service>at</service>
    <service>sshd</service>
  </enable>
  <disable config:type="list">
    <service>libvirtd</service>
  </disable>
  <on_demand config:type="list">
    <service>cups</service>
  </on_demand>
</services>
```

Additionally, this PR adds proper errors reporting as shown in the screenshot below.
![autoyast-services-manager-errors](https://user-images.githubusercontent.com/15836/43913820-075064a6-9bfe-11e8-9f61-2bb129f13777.png)
