### PR TITLE
Improve UX when "applying" changes

### DIFF
--- a/src/lib/services-manager/dialogs/services_manager.rb
+++ b/src/lib/services-manager/dialogs/services_manager.rb
@@ -137,12 +137,11 @@ module Y2ServicesManager
         _("Services Manager")
       end
 
-      # TODO
       # Dialog help
       #
       # @return [String]
       def help
-        ""
+        services_table.help
       end
 
       # Dialog content
@@ -280,6 +279,15 @@ module Y2ServicesManager
         end
 
         handler
+      end
+
+      # Handler for help event (help button is used)
+      #
+      # A popup with help is shown
+      def help_handler
+        self.finish = false
+
+        show_help
       end
 
       # Handler for abort event (abort button is used)
@@ -432,6 +440,11 @@ module Y2ServicesManager
         )
 
         Popup::ContinueCancel(message)
+      end
+
+      # Opens up a popup with the help text
+      def show_help
+        Yast2::Popup.show(help, richtext: true, headline: _("Help"), buttons: :ok)
       end
 
       # Applies all changes indicated for each service

--- a/src/lib/services-manager/dialogs/services_manager.rb
+++ b/src/lib/services-manager/dialogs/services_manager.rb
@@ -20,6 +20,7 @@
 # find current contact information at www.suse.com.
 
 require "yast"
+require "yast2/popup"
 require "yast2/feedback"
 require "services-manager/widgets/base"
 require "services-manager/widgets/target_selector"
@@ -303,8 +304,11 @@ module Y2ServicesManager
 
       # Handler for next event (accept button is used)
       #
-      # @note It finishes the dialog if all changes were correctly applied.
+      # @note A confirmation popup is shown and it finishes the dialog if all
+      #   changes were correctly applied.
       def next_handler
+        return unless confirm_changes?
+
         self.success = save
 
         if !success && continue_editing?
@@ -317,8 +321,11 @@ module Y2ServicesManager
 
       # Handler for apply event (apply button is used)
       #
-      # @note It does not finish the dialog when all changes were correctly applied.
+      # @note A confirmation popup is shown and it does not finish the dialog when
+      #   all changes were correctly applied.
       def apply_handler
+        return unless confirm_changes?
+
         self.success = save
 
         if success || continue_editing?
@@ -407,6 +414,17 @@ module Y2ServicesManager
         Y2Journal::EntriesDialog.new(query: query).run
 
         services_table.focus
+      end
+
+      # When there are changes, it opens up a confirmation popup with a summary of all changes
+      #
+      # @return [Boolean]
+      def confirm_changes?
+        return true unless Yast::ServicesManager.modified?
+
+        message = Yast::ServicesManager.changes_summary + _("Apply all changes?")
+
+        Yast2::Popup.show(message, richtext: true, headline: _("Summary of changes"), buttons: :yes_no) == :yes
       end
 
       # Opens up a popup to ask the user whether to continue editing

--- a/src/lib/services-manager/dialogs/services_manager.rb
+++ b/src/lib/services-manager/dialogs/services_manager.rb
@@ -302,8 +302,8 @@ module Y2ServicesManager
 
       # Handler for next event (accept button is used)
       #
-      # @note A confirmation popup is shown and it finishes the dialog if all
-      #   changes were correctly applied.
+      # @note A confirmation popup is shown when there is any change and it finishes
+      #   the dialog if all changes were correctly applied.
       def next_handler
         return unless confirm_changes?
 

--- a/src/lib/services-manager/widgets/services_table.rb
+++ b/src/lib/services-manager/widgets/services_table.rb
@@ -120,7 +120,31 @@ module Y2ServicesManager
       #
       # @return [Yast2::SystemService, nil] nil if the service is not found
       def selected_service
-        ServicesManagerService.find(selected_service_name)
+        service(selected_service_name)
+      end
+
+      # Help text
+      #
+      # @return [String]
+      def help
+        # TRANSLATORS: help text to explain the columns of the services table
+        _(
+          "<b>Service</b> shows the name of the service." \
+          "<br />" \
+          "<b>Start</b> shows the start mode of the service:" \
+          "<ul>" \
+            "<li>On Boot: the service will be automatically started after booting the system.</li>" \
+            "<li>On Demand: the service will be automatically started when needed.</li>" \
+            "<li>Manually: the service will not be automatically started.</li>" \
+          "</ul>" \
+          "<b>State</b> shows the state and substate of the service." \
+          "<br />" \
+          "<b>Description</b> shows the description of the service." \
+          "<br />" \
+          "<br />" \
+          "Note: edited values are marked with '(*)'. These new values will be saved by " \
+          "using 'Apply' or 'OK' button."
+        )
       end
 
     private

--- a/src/lib/services-manager/widgets/services_table.rb
+++ b/src/lib/services-manager/widgets/services_table.rb
@@ -217,26 +217,36 @@ module Y2ServicesManager
 
       # Value for the start_mode column of a service
       #
+      # @note The value contains a special mark when it has been edited by the user,
+      #   see {#highlight_value}.
+      #
       # @param service_name [String]
       # @return [String]
       def start_mode_value(service_name)
-        ServicesManagerService.start_mode_to_human_for(service_name)
+        value = ServicesManagerService.start_mode_to_human_for(service_name)
+
+        value = highlight_value(value) if service(service_name).changed?(:start_mode)
+
+        value
       end
 
       # Value for the state column of a service
       #
+      # By default it shows the current service status, but if the user starts or stops
+      # the service, then it shows the fixed text "Active" or "Inactive", see {#current_state_value}
+      # and {#future_state_value}.
+      #
+      # @note The value contains a special mark when it has been edited by the user,
+      #   see {#highlight_value}.
+      #
       # @param service_name [String]
       # @return [String]
       def state_value(service_name)
-        state = TRANSLATIONS[:service_state][service_state(service_name)]
-        substate = TRANSLATIONS[:service_substate][service_substate(service_name)]
+        service = service(service_name)
 
-        return _(state) unless substate
+        return current_state_value(service) unless service.changed?(:active)
 
-        # TRANSLATORS: state of a service, as showed by systemctl (e.g., "Active (Running)").
-        # %{state} is replaced by the service state (e.g. "Active", "Inactive", etc) and
-        # %{substate} is replaced by the service substate (e.g., "Start", "Stop", "Exited", etc).
-        format(_("%{state} (%{substate})"), state: _(state), substate: _(substate))
+        future_state_value(service)
       end
 
       # Value for the description column of a service
@@ -247,20 +257,47 @@ module Y2ServicesManager
         ServicesManagerService.description(service_name) || ""
       end
 
-      # State of a service
+      # Text for the current state of the service
       #
-      # @param service_name [String]
+      # @param service [Yast2::SystemService]
       # @return [String]
-      def service_state(service_name)
-        ServicesManagerService.state(service_name) || ""
+      def current_state_value(service)
+        state = TRANSLATIONS[:service_state][service.state]
+        substate = TRANSLATIONS[:service_substate][service.substate]
+
+        return _(state) unless substate
+
+        # TRANSLATORS: state of a service, as showed by systemctl (e.g., "Active (Running)").
+        # %{state} is replaced by the service state (e.g. "Active", "Inactive", etc) and
+        # %{substate} is replaced by the service substate (e.g., "Start", "Stop", "Exited", etc).
+        format(_("%{state} (%{substate})"), state: _(state), substate: _(substate))
       end
 
-      # Substate of a service
+      # Text for the future state of the service
+      #
+      # @note It contains a special mark, see {#highlight_value}.
+      #
+      # @param service [Yast2::SystemService]
+      # @return [String]
+      def future_state_value(service)
+        value = service.active? ? _("Active") : _("Inactive")
+        highlight_value(value)
+      end
+
+      # Adds a special mark to highlight the value (e.g., when the value has been edited)
+      #
+      # @param value [String]
+      # @return [String]
+      def highlight_value(value)
+        "(*) " + value
+      end
+
+      # Service object
       #
       # @param service_name [String]
-      # @return [String]
-      def service_substate(service_name)
-        ServicesManagerService.substate(service_name) || ""
+      # @return [Yast2::SystemService, nil] nil if the service is not found
+      def service(service_name)
+        ServicesManagerService.find(service_name)
       end
 
       # Updates the value for the start_mode column of a service
@@ -274,16 +311,7 @@ module Y2ServicesManager
       #
       # @param service_name [String]
       def refresh_state_value(service_name)
-        active_changed = ServicesManagerService.find(service_name).changed?(:active)
-        will_be_active = ServicesManagerService.active?(service_name)
-
-        state = if active_changed
-          will_be_active ? _('Active (will start)') : _('Inactive (will stop)')
-        else
-          state_value(service_name)
-        end
-
-        UI.ChangeWidget(id, Cell(service_name, 2), state)
+        UI.ChangeWidget(id, Cell(service_name, 2), state_value(service_name))
       end
 
       # Max width of a column

--- a/src/lib/services-manager/widgets/target_selector.rb
+++ b/src/lib/services-manager/widgets/target_selector.rb
@@ -51,6 +51,11 @@ module Y2ServicesManager
         UI.QueryWidget(id, :Value)
       end
 
+      # Refreshes the widget content
+      def refresh
+        UI.ChangeWidget(id, :Items, system_targets_items)
+      end
+
     private
 
       # Default widget id

--- a/src/modules/services_manager.rb
+++ b/src/modules/services_manager.rb
@@ -45,7 +45,7 @@ module Yast
       end
     end
 
-    def import data
+    def import(data)
       profile = ServicesManagerProfile.new(data)
       ServicesManagerTarget.import(profile)
       ServicesManagerService.import(profile)
@@ -92,6 +92,13 @@ module Yast
       true
     end
 
+    # Summary of changes
+    #
+    # @return [String]
+    def changes_summary
+      ServicesManagerTarget.changes_summary + ServicesManagerService.changes_summary
+    end
+
     publish({:function => :export,      :type => "map <string, any> ()"          })
     publish({:function => :import,      :type => "boolean ()"                    })
     publish({:function => :modified,    :type => "boolean ()"                    })
@@ -99,7 +106,7 @@ module Yast
     publish({:function => :read,        :type => "void ()"                       })
     publish({:function => :reset,       :type => "void ()"                       })
     publish({:function => :save,        :type => "map <string, string> (boolean)"})
-
   end
+
   ServicesManager = ServicesManagerClass.new
 end

--- a/src/modules/services_manager_service.rb
+++ b/src/modules/services_manager_service.rb
@@ -548,10 +548,10 @@ module Yast
       )
     end
 
-    # Returns the name of the given services
+    # Returns the name of the given services, joined by comma.
     #
     # @param services [Array<Yast2::SystemService>]
-    # @return [Array<String>]
+    # @return [String]
     def services_names(services)
       services.map(&:name).join(", ")
     end

--- a/test/dialogs/services_manager_test.rb
+++ b/test/dialogs/services_manager_test.rb
@@ -351,5 +351,17 @@ describe Y2ServicesManager::Dialogs::ServicesManager do
         subject.run
       end
     end
+
+    context "when user selects 'Help' button" do
+      let(:user_input) { [:help, :cancel] }
+
+      it "shows a popup with the help" do
+        expect(Yast2::Popup).to receive(:show) do |message, options|
+          expect(options[:headline]).to match(/Help/)
+        end
+
+        subject.run
+      end
+    end
   end
 end

--- a/test/dialogs/services_manager_test.rb
+++ b/test/dialogs/services_manager_test.rb
@@ -172,6 +172,19 @@ describe Y2ServicesManager::Dialogs::ServicesManager do
 
         subject.run
       end
+
+      context "and there are no changes yet" do
+        before do
+          allow(Yast::ServicesManager).to receive(:modified?).and_return(false)
+          allow(Yast::UI).to receive(:ChangeWidget).and_call_original
+        end
+
+        it "disables the 'Apply' button" do
+          expect(Yast::UI).to receive(:ChangeWidget).with(Id(:apply), :Enabled, false)
+
+          subject.run
+        end
+      end
     end
 
     context "when apply button should not be shown" do

--- a/test/services_manager_test.rb
+++ b/test/services_manager_test.rb
@@ -1,4 +1,24 @@
 #!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require_relative 'test_helper'
 
@@ -225,6 +245,33 @@ module Yast
         allow(Yast::ServicesManagerService).to receive(:reset)
         allow(Yast::ServicesManagerTarget).to receive(:reset)
         expect(subject.reset).to eq(nil)
+      end
+    end
+
+    describe "#changes_summary" do
+      before do
+        allow(Yast::ServicesManagerTarget).to receive(:changes_summary).and_return(target_changes)
+        allow(Yast::ServicesManagerService).to receive(:changes_summary).and_return(services_changes)
+      end
+
+      let(:target_changes) { "target changes" }
+      let(:services_changes) { "services changes" }
+
+      it "contains the summary of changes for the default target" do
+        expect(subject.changes_summary).to include(target_changes)
+      end
+
+      it "contains the summary of changes for the services" do
+        expect(subject.changes_summary).to include(services_changes)
+      end
+
+      context "when there are no changes" do
+        let(:target_changes) { "" }
+        let(:services_changes) { "" }
+
+        it "returns an empty text" do
+          expect(subject.changes_summary).to be_empty
+        end
       end
     end
   end

--- a/test/widgets/services_table_test.rb
+++ b/test/widgets/services_table_test.rb
@@ -89,4 +89,11 @@ describe Y2ServicesManager::Widgets::ServicesTable do
       expect(subject.selected_service.name).to eq(selected_service_name)
     end
   end
+
+  describe "#help" do
+    it "returns the help text" do
+      expect(subject.help).to be_a(String)
+      expect(subject.help).to match(/shows the name/)
+    end
+  end
 end


### PR DESCRIPTION
PBI: https://trello.com/c/4syvDr0I/180-improve-services-manager-ux

Now, edited values of each service are highlighted by using a special mark (i.e., "(*)"). Ideally, all the row should be marked in bold, to indicate that the service has been edited.

To allow bold text inside a Table widget, some changes are required in yast-ycp-ui-bindings, libyui, libyiu-qt and libyui-ncurses. I'm trying to do it, but without success till now.