### PR TITLE
Define %yast_icondir

### DIFF
--- a/package/yast2-services-manager.spec
+++ b/package/yast2-services-manager.spec
@@ -79,6 +79,7 @@ rake install DESTDIR="%{buildroot}"
 %suse_update_desktop_file services-manager
 
 %define yast_dir %{_prefix}/share/YaST2
+%define yast_icondir %{_datadir}/icons
 
 %files
 %defattr(-,root,root)


### PR DESCRIPTION
- This package does not use the shared RPM macros from yast2-devtools :open_mouth: 
- See https://github.com/yast/yast-devtools/pull/135/files#diff-0fc23eb95cef73cdbc8baba0bdc8729aR9 for th echange in the yast2-devtools package.