### PR TITLE
New systemd States

### DIFF
--- a/devel/expected_states.yml
+++ b/devel/expected_states.yml
@@ -22,6 +22,6 @@ service unit substates:
 - start-pre
 - stop
 - stop-post
-- stop-sigabrt
 - stop-sigkill
 - stop-sigterm
+- stop-watchdog


### PR DESCRIPTION
# Trello

https://trello.com/c/2OowfKsQ/

# Check Script Output


```diff
Found expected states in the "unit active states" group
Found difference in the "service unit substates" group:
--- Expected states
+++ Current states
@@ -11,6 +11,6 @@
 start-pre
 stop
 stop-post
-stop-sigabrt
 stop-sigkill
 stop-sigterm
+stop-watchdog

Check failed!
```