### PR TITLE
Adapt systemd states to upstream changes

### DIFF
--- a/package/yast2-services-manager.changes
+++ b/package/yast2-services-manager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May  8 15:20:54 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Adapted systemd states to upstream changes:
+  New stop-watchdog, no more stop-sigabrt
+- 4.1.15
+
+-------------------------------------------------------------------
 Wed Feb 13 16:38:31 CET 2019 - schubi@suse.de
 
 - Upgrade: Do not write default target if it has not been set.

--- a/package/yast2-services-manager.changes
+++ b/package/yast2-services-manager.changes
@@ -2,8 +2,8 @@
 Wed May  8 15:20:54 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Adapted systemd states to upstream changes:
-  New stop-watchdog, no more stop-sigabrt
-- 4.1.15
+  New stop-watchdog, no more stop-sigabrt (bsc#1134571)
+- 4.2.0
 
 -------------------------------------------------------------------
 Wed Feb 13 16:38:31 CET 2019 - schubi@suse.de

--- a/package/yast2-services-manager.spec
+++ b/package/yast2-services-manager.spec
@@ -24,7 +24,7 @@
 ######################################################################
 
 Name:           yast2-services-manager
-Version:        4.1.14
+Version:        4.1.15
 Release:        0
 BuildArch:      noarch
 

--- a/src/lib/services-manager/widgets/services_table.rb
+++ b/src/lib/services-manager/widgets/services_table.rb
@@ -56,9 +56,9 @@ module Y2ServicesManager
           "start-pre"     => N_("Start-pre"),
           "stop"          => N_("Stop"),
           "stop-post"     => N_("Stop-post"),
-          "stop-sigabrt"  => N_("Stop-sigabrt"),
           "stop-sigkill"  => N_("Stop-sigkill"),
-          "stop-sigterm"  => N_("Stop-sigterm")
+          "stop-sigterm"  => N_("Stop-sigterm"),
+          "stop-watchdog" => N_("Stop-watchdog")
         }
       }
       private_constant :TRANSLATIONS


### PR DESCRIPTION
# Trello

https://trello.com/c/2OowfKsQ/

# Related PR

https://github.com/yast/yast-services-manager/pull/190

# Description

Adapted the one place where the old `systemd-sigabrt` state was ever used in the complete source tree: Removed the now obsolete `systemd-sigabrt` state and added `systemd-watchdog` instead.

AFAICS this is only reporting the state to the user; there does not seem to be any more semantics  behind it in this YaST module.

# Upstream Changes (in systemd)

https://github.com/systemd/systemd/blob/master/src/basic/unit-def.c#L172

That was part of this upstream PR:

https://github.com/systemd/systemd/commit/c87700a1335f489be31cd3549927da68b5638819

## man systemd.service

> WatchdogSec=
>
> Configures the watchdog timeout for a service. The watchdog is activated when the start-up is completed. The service must call sd_notify(3) regularly with "WATCHDOG=1" (i.e. the "keep-alive ping"). If the time between two such calls is larger than the configured time, then the service is placed in a failed state and it will be terminated with SIGABRT (or the signal specified by **_WatchdogSignal_**=). 

So this is just a generalization of the concept of SIGABRT: It is now more generally called the _watchdog signal_, and it can be configured individually for each service. The default still appears to be SIGABRT, but systemd and related tools now call it _watchdog signal_, thus the change from `stop-sigabrt` to `stop-watchdog`.

# Bottom Line

Nothing to worry for us. It's just a rename.
