### PR TITLE
Reduce exported profile

### DIFF
--- a/package/yast2-services-manager.changes
+++ b/package/yast2-services-manager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jun 30 11:48:27 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Honor the 'target' argument when cloning the system. If it is
+  set to 'compact', it only export those services which start
+  mode is not set to their predefined values (bsc#1172749).
+- 4.3.1
+
+-------------------------------------------------------------------
 Tue May 12 15:32:28 UTC 2020 - josef Reidinger <jreidinger@localhost>
 
 - Autoyast schema: Allow optional types for string and map objects

--- a/package/yast2-services-manager.changes
+++ b/package/yast2-services-manager.changes
@@ -2,7 +2,7 @@
 Tue Jun 30 11:48:27 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Honor the 'target' argument when cloning the system. If it is
-  set to 'compact', it only export those services which start
+  set to 'compact', it only exports those services which start
   mode is not set to their predefined values (bsc#1172749).
 - 4.3.1
 

--- a/package/yast2-services-manager.spec
+++ b/package/yast2-services-manager.spec
@@ -35,8 +35,8 @@ Source0:        %{name}-%{version}.tar.bz2
 
 BuildRequires:  ruby
 BuildRequires:  update-desktop-files
-# Yast2::Firewalld::Interface#zone returns a Zone object
-BuildRequires:  yast2 >= 4.1.17
+# 'target' argument for Installation::AutoClient#export method
+BuildRequires:  yast2 >= 4.3.10
 BuildRequires:  yast2-ruby-bindings >= 1.2.0
 # To show service logs
 BuildRequires:  yast2-journal >= 4.1.1
@@ -46,8 +46,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
 BuildRequires:  yast2-devtools >= 4.2.2
 
 Requires:       ruby
-# Yast2::Firewalld::Interface#zone returns a Zone object
-Requires:       yast2 >= 4.1.17
+ # 'target' argument for Installation::AutoClient#export method
+Requires:       yast2 >= 4.3.10
 Requires:       yast2-ruby-bindings >= 1.2.0
 
 # To show service logs

--- a/package/yast2-services-manager.spec
+++ b/package/yast2-services-manager.spec
@@ -24,7 +24,7 @@
 ######################################################################
 
 Name:           yast2-services-manager
-Version:        4.3.0
+Version:        4.3.1
 Release:        0
 Summary:        YaST2 - Services Manager
 Group:          System/YaST

--- a/src/lib/services-manager/clients/auto.rb
+++ b/src/lib/services-manager/clients/auto.rb
@@ -46,8 +46,8 @@ module Y2ServicesManager
       end
 
       # @see ::Installation::AutoClient#export
-      def export
-        Yast::ServicesManager.export
+      def export(target: :default)
+        Yast::ServicesManager.export(target: target)
       end
 
       # @see ::Installation::AutoClient#read

--- a/src/modules/services_manager.rb
+++ b/src/modules/services_manager.rb
@@ -29,10 +29,13 @@ module Yast
       textdomain 'services-manager'
     end
 
-    def export
+    # @param target [Symbol] Control how much information should be exported
+    #   (e.g., :default or :compact).
+    # @return [Hash] profile data
+    def export(target: :default)
       {
         TARGET   => ServicesManagerTarget.export,
-        SERVICES => ServicesManagerService.export
+        SERVICES => ServicesManagerService.export(target: target)
       }
     end
 

--- a/src/modules/services_manager_service.rb
+++ b/src/modules/services_manager_service.rb
@@ -111,7 +111,7 @@ module Yast
     # @param key [Symbol] value that has been changed (:active and :start_mode)
     # @return [Boolean] true if the key has changed
     def changed_value?(name, key)
-      exists?(name) { |s| s.changed?(:active) }
+      exists?(name) { |s| s.changed?(key) }
     end
 
     # Returns whether the given service has been enabled

--- a/src/modules/services_manager_service.rb
+++ b/src/modules/services_manager_service.rb
@@ -220,7 +220,10 @@ module Yast
       log.info "Exported services: on boot: #{on_boot_srvs}; on-demand: #{on_demand_srvs}; " \
         "disabled: #{disabled_srvs}"
 
-      { "enable" => on_boot_srvs, "on_demand" => on_demand_srvs, "disable" => disabled_srvs }
+      exported = {
+        "enable" => on_boot_srvs, "on_demand" => on_demand_srvs, "disable" => disabled_srvs
+      }
+      exported.reject { |_k, v| v.empty? }
     end
 
     # Selects which services should be exported

--- a/test/services_manager_service_test.rb
+++ b/test/services_manager_service_test.rb
@@ -314,11 +314,7 @@ describe Yast::ServicesManagerServiceClass do
         end
 
         it "does not return any list" do
-          expect(exported_services).to eq(
-            "disable" => [],
-            "enable" => [],
-            "on_demand" => []
-          )
+          expect(exported_services).to eq({})
         end
       end
 
@@ -346,7 +342,6 @@ describe Yast::ServicesManagerServiceClass do
         exported = subject.export
         expect(exported["on_demand"]).to include("dbus")
         expect(exported["enable"]).to_not include("dbus")
-        expect(exported["disable"]).to_not include("dbus")
       end
     end
 
@@ -371,8 +366,8 @@ describe Yast::ServicesManagerServiceClass do
         end
 
         it "exports the service as disabled" do
-          expect(exported_services["enable"]).to_not include("cups")
           expect(exported_services["disable"]).to include("cups")
+          expect(exported_services["enable"]).to be_nil
         end
       end
 
@@ -383,7 +378,7 @@ describe Yast::ServicesManagerServiceClass do
 
         it "exports the service as enable" do
           expect(exported_services["enable"]).to include("cups")
-          expect(exported_services["disable"]).to_not include("cups")
+          expect(exported_services["disable"]).to be_nil
         end
       end
 
@@ -394,8 +389,8 @@ describe Yast::ServicesManagerServiceClass do
 
         it "exports the service to be started on demand" do
           expect(exported_services["on_demand"]).to include("cups")
-          expect(exported_services["enable"]).to_not include("cups")
-          expect(exported_services["disable"]).to_not include("cups")
+          expect(exported_services["enable"]).to be_nil
+          expect(exported_services["disable"]).to be_nil
         end
       end
 


### PR DESCRIPTION
Honor the `target` argument by exporting only those services which has changed regarding its preset start_mode. See [AutoYaST2 PR](https://github.com/yast/yast-autoinstallation/pull/631) for further information.

Changes:

* Add an optional "target" argument to the ServicesManager.export method.