### PR TITLE
Fix changing other services than the user expects

### DIFF
--- a/package/yast2-services-manager.changes
+++ b/package/yast2-services-manager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug 10 15:18:56 UTC 2020 - Martin Vidner <mvidner@suse.com>
+
+- Fix changing other services than the user expects (bsc#1165388,
+  bsc#1174615)
+- 4.2.7
+
+-------------------------------------------------------------------
 Wed Jul 29 11:15:35 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix detection of modifications in AutoYaST config mode

--- a/package/yast2-services-manager.spec
+++ b/package/yast2-services-manager.spec
@@ -24,7 +24,7 @@
 ######################################################################
 
 Name:           yast2-services-manager
-Version:        4.2.6
+Version:        4.2.7
 Release:        0
 Summary:        YaST2 - Services Manager
 Group:          System/YaST

--- a/src/lib/services-manager/widgets/services_table.rb
+++ b/src/lib/services-manager/widgets/services_table.rb
@@ -79,7 +79,7 @@ module Y2ServicesManager
 
       # @return [Yast::Term]
       def widget
-        @table ||= Table(id, Opt(:immediate), header, items)
+        @table ||= Table(id, Opt(:immediate, :keepSorting), header, items)
       end
 
       # Sets focus on the table


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1165388 (Leap 15.2), https://trello.com/c/FHZyHFj5
- https://bugzilla.suse.com/show_bug.cgi?id=1174615 (L3, SLE15-SP2), https://trello.com/c/oWsZbu67


As reported:

> When I select for example auditd and change its Start Mode from "On
> Boot" to "(\*) Manually" (and/or its State from "Active (Running)" to
> "(\*) Inactive"), the item YaST2-Second-Stage (that is two lines above
> auditd) is visually marked as to be changed instead. But the change(s)
> will be actually correctly applied to auditd.

Cause:

There is a long-standing bug in libyui-ncurses that is mostly hidden by
circumstances. This commit does not fix that bug, only works around it.

Services Manager does something other YaST modules don't do: it changes
table contents cell by cell instead of wholesale.

The ncurses (TUI) version of the table widget has a bug where this
individual cell change ignores table sorting that may be set up.

The bug seems to be old but it was masked by sorting being initially
disabled for all tables. You had to press Ctrl-O to reorder the table.
Since SLE/Leap 15.2 tables are initially sorted so the bug triggers. The
workaround is to add the `:keepSorting` option which disables both the
initial sorting and the user-triggered one.

Another factor masking the bug is the fact that application code, aware
that tables will not sort, was sorting the items before inserting them
in tables. So in many cases the application order and the table order
are the same and the bug is hidden. But if there are items in lowercase
as well as Uppercase the two sort algorithms disagree and the bug
becomes apparent.