### PR TITLE
Re-enable service table sorting (bsc#1165388, bsc#1174615)

### DIFF
--- a/package/yast2-services-manager.changes
+++ b/package/yast2-services-manager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Aug 27 09:43:49 UTC 2020 - Martin Vidner <mvidner@suse.com>
+
+- Re-enable service table sorting (bsc#1165388, bsc#1174615).
+- 4.3.5
+
+-------------------------------------------------------------------
 Mon Aug 10 18:06:31 CEST 2020 - schubi@suse.de
 
 - AutoYaST: Added supplements: autoyast(services_manager) into the

--- a/package/yast2-services-manager.spec
+++ b/package/yast2-services-manager.spec
@@ -24,7 +24,7 @@
 ######################################################################
 
 Name:           yast2-services-manager
-Version:        4.3.4
+Version:        4.3.5
 Release:        0
 Summary:        YaST2 - Services Manager
 Group:          System/YaST

--- a/src/lib/services-manager/widgets/services_table.rb
+++ b/src/lib/services-manager/widgets/services_table.rb
@@ -79,7 +79,7 @@ module Y2ServicesManager
 
       # @return [Yast::Term]
       def widget
-        @table ||= Table(id, Opt(:immediate, :keepSorting), header, items)
+        @table ||= Table(id, Opt(:immediate), header, items)
       end
 
       # Sets focus on the table


### PR DESCRIPTION
This reverts commit c94e549. (#206)

The workaround is no longer necessary after a proper fix in libyui-ncurses,
(libyui-ncurses-2.56.2, libyui/libyui-ncurses#100)
and is useful to be able to sort services by their enabled/running state.



