### PR TITLE
Fix popup

### DIFF
--- a/package/yast2-services-manager.changes
+++ b/package/yast2-services-manager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 15 09:06:09 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- Adapted unit test to recent changes in Yast::Report (related to
+  bsc#1179893).
+- 4.3.6
+
+-------------------------------------------------------------------
 Thu Aug 27 09:43:49 UTC 2020 - Martin Vidner <mvidner@suse.com>
 
 - Re-enable service table sorting (bsc#1165388, bsc#1174615).

--- a/package/yast2-services-manager.spec
+++ b/package/yast2-services-manager.spec
@@ -24,7 +24,7 @@
 ######################################################################
 
 Name:           yast2-services-manager
-Version:        4.3.5
+Version:        4.3.6
 Release:        0
 Summary:        YaST2 - Services Manager
 Group:          System/YaST

--- a/test/services_manager_profile_test.rb
+++ b/test/services_manager_profile_test.rb
@@ -191,6 +191,7 @@ module Yast
       end
 
       it "provides empty list of services" do
+        expect(Yast::Report).to receive(:Error)
         expect(profile.services).to be_empty
       end
     end


### PR DESCRIPTION
This pull request in yast-yast2 (https://github.com/yast/yast-yast2/pull/1122) changed the behavior during unit tests of `Yast::Report` and `Yast2::Popup`, making necessary to add some extra mocking to prevent YaST from trying to open windows during the test execution.

As far as we know, that affected the test-suites of: yast-storage-ng, yast-country, yast-firewall, yast-nfs-server, yast-nis-client, yast-pam, yast-security, yast-services-manager and yast-sysconfig.

This should fix the problem for this repository.