### PR TITLE
Update expected systemd states

### DIFF
--- a/expected_states.yml
+++ b/expected_states.yml
@@ -7,14 +7,18 @@ unit active states:
 - deactivating
 - failed
 - inactive
+- maintenance
 - reloading
 service unit substates:
 - auto-restart
+- cleaning
+- condition
 - dead
 - exited
 - failed
 - final-sigkill
 - final-sigterm
+- final-watchdog
 - reload
 - running
 - start


### PR DESCRIPTION
Update expected systemd states with the new ones found by the systemd_status_check.rb script[1]
on Aug 4, 2021[2]

```
Run ./systemd_status_check.rb

Found difference in the "unit active states" group:
--- Expected states
+++ Current states
@@ -3,4 +3,5 @@
 deactivating
 failed
 inactive
+maintenance
 reloading

Found difference in the "service unit substates" group:
--- Expected states
+++ Current states
@@ -1,9 +1,12 @@
 auto-restart
+cleaning
+condition
 dead
 exited
 failed
 final-sigkill
 final-sigterm
+final-watchdog
 reload
 running
 start

Check failed!
```

---

Related PRs:

* https://github.com/yast/yast-services-manager/pull/213

---


[1] https://github.com/yast/yast-services-manager/blob/check_systemd_states/systemd_status_check.rb
[2] https://github.com/yast/yast-services-manager/runs/3238884448?check_suite_focus=true