### PR TITLE
document recently added systemd unit states/substates

### DIFF
--- a/src/lib/services-manager/widgets/services_table.rb
+++ b/src/lib/services-manager/widgets/services_table.rb
@@ -32,7 +32,7 @@ module Y2ServicesManager
       # Systemd states and substates might change. Use the following script to check
       # whether new states are not considered yet:
       #
-      # https://github.com/yast/yast-services-manager/blob/systemd_states_check/devel/systemd_status_check.rb
+      # https://github.com/yast/yast-services-manager/blob/check_systemd_states/systemd_status_check.rb
       TRANSLATIONS = {
         service_state: {
           "activating"   => N_("Activating"),


### PR DESCRIPTION
- https://trello.com/c/8GYaBEp6
- Followup to https://github.com/yast/yast-services-manager/pull/213

In the end the `master` branch only needs a small fix, because the checking logic lives in a separate(!) branch.
The following notes were summarized in #215 and code was changed in https://github.com/yast/yast-yast2/pull/1192 

<details>
 <summary>Here are my original notes</summary>
- unit states

  These are important because we need to know whether the new state is
  basically active or inactive, to switch between the Start/Stop buttons

  - maintenance

- service substates

  We shouldn't need to care about these except for translations (add links to
  upstream docs/implementation for translators that care about accuracy)

  - final-watchdog
    - group with other final* (currently not handled)
    - upstream added in https://github.com/systemd/systemd/pull/12334
    - -> deactivating
  - cleaning
    - upstream added in https://github.com/systemd/systemd/pull/12176
    - triggered by `systemctl clean`
    - -> maintenance
  - condition
    - upstream added in https://github.com/systemd/systemd/pull/12933
    - -> activating, active

    see
    https://github.com/systemd/systemd/blob/31cd5f63ce86a0784c4ef869c4d323a11ff14adc/src/core/service.c
    state_translation_table and state_translation_table_idle
</details>

