### PR TITLE
Explicitly pull in systemctl for buildtime tests

### DIFF
--- a/package/yast2-services-manager.changes
+++ b/package/yast2-services-manager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul  7 09:44:23 UTC 2022 - Fabian Vogt <fvogt@suse.com>
+
+- Explicitly pull in systemctl for buildtime tests
+- 4.5.1
+
+-------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.5.0 (bsc#1198109)

--- a/package/yast2-services-manager.spec
+++ b/package/yast2-services-manager.spec
@@ -44,6 +44,8 @@ BuildRequires:  yast2-journal >= 4.1.1
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake) >= 0.1.7
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
 BuildRequires:  yast2-devtools >= 4.2.2
+# The tests need systemctl
+BuildRequires:  pkgconfig(systemd)
 
 Requires:       ruby
  # 'target' argument for Installation::AutoClient#export method

--- a/package/yast2-services-manager.spec
+++ b/package/yast2-services-manager.spec
@@ -24,7 +24,7 @@
 ######################################################################
 
 Name:           yast2-services-manager
-Version:        4.5.0
+Version:        4.5.1
 Release:        0
 Summary:        YaST2 - Services Manager
 Group:          System/YaST


### PR DESCRIPTION
Until now this was added indirectly through yast2-sysconfig -> sysconfig -> sysconfig-netconfig -> util-linux-systemd, but with the latest sysconfig change this is no longer the case.

This fixes the failure in TW Staging :D.