### PR TITLE
Improved Help Text for Services Table

### DIFF
--- a/package/yast2-services-manager.changes
+++ b/package/yast2-services-manager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon May 15 13:36:23 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Improved help text for services table (bsc#1211320)
+- 4.6.1
+
+-------------------------------------------------------------------
 Fri Mar 03 14:44:07 UTC 2023 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.6.0 (bsc#1208913)

--- a/package/yast2-services-manager.spec
+++ b/package/yast2-services-manager.spec
@@ -24,7 +24,7 @@
 ######################################################################
 
 Name:           yast2-services-manager
-Version:        4.6.0
+Version:        4.6.1
 Release:        0
 Summary:        YaST2 - Services Manager
 Group:          System/YaST

--- a/src/lib/services-manager/widgets/services_table.rb
+++ b/src/lib/services-manager/widgets/services_table.rb
@@ -133,7 +133,8 @@ module Y2ServicesManager
       def help
         # TRANSLATORS: help text to explain the columns of the services table
         _(
-          "<h2>The table contains the following information:</h2>" \
+          "<h2>The Services Table</h2>" \
+          "<p>This table contains <b>all services</b> with the following information about each service:</p>" \
           "<b>Service</b> shows the name of the service." \
           "<br />" \
           "<b>Start</b> shows the start mode of the service:" \


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1211320


## Problem

![y-services-manager](https://github.com/yast/yast-services-manager/assets/11538225/fb8c18b1-0193-451e-877b-801e64994279)

A user was surprised when the content of the services table did not change after changing the "Default System Target" above it.

The (wrong) expectation was that this is some kind of filter for the table, but it's really unrelated: It only changes the target to which the system will boot.


## Fix

Improved the help text to clarify what the table contains.

### Old Help Text

![services-help-old](https://github.com/yast/yast-services-manager/assets/11538225/2ed6fd1d-cad1-4d9c-a35c-ffd44ec7881a)


### New Help Text

![services-help-new](https://github.com/yast/yast-services-manager/assets/11538225/c1bd5769-5462-406d-b818-bf72632f1841)

