### PR TITLE
Backport sp6

### DIFF
--- a/package/yast2-services-manager.changes
+++ b/package/yast2-services-manager.changes
@@ -2,6 +2,9 @@
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)
+- Backport from TW:
+-- Improved help text for services table (bsc#1211320)
+- 4.6.1
 
 -------------------------------------------------------------------
 Thu Jul  7 09:44:23 UTC 2022 - Fabian Vogt <fvogt@suse.com>

--- a/package/yast2-services-manager.spec
+++ b/package/yast2-services-manager.spec
@@ -24,7 +24,7 @@
 ######################################################################
 
 Name:           yast2-services-manager
-Version:        4.6.0
+Version:        4.6.1
 Release:        0
 Summary:        YaST2 - Services Manager
 Group:          System/YaST

--- a/src/lib/services-manager/widgets/services_table.rb
+++ b/src/lib/services-manager/widgets/services_table.rb
@@ -133,7 +133,8 @@ module Y2ServicesManager
       def help
         # TRANSLATORS: help text to explain the columns of the services table
         _(
-          "<h2>The table contains the following information:</h2>" \
+          "<h2>The Services Table</h2>" \
+          "<p>This table contains <b>all services</b> with the following information about each service:</p>" \
           "<b>Service</b> shows the name of the service." \
           "<br />" \
           "<b>Start</b> shows the start mode of the service:" \


### PR DESCRIPTION
## Problem

SLE 15 SP6 branch is based on SLE15 SP5 maintenance branch. So fixes done in master can be sometimes useful also for SP6.


## Solution

backport the only patch and keep version.