### PR TITLE
Remove nscd-related Code

### DIFF
--- a/package/yast2-services-manager.changes
+++ b/package/yast2-services-manager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jan 28 10:17:29 UTC 2025 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Remove nscd-related code (bsc#1236308)
+- 5.0.1
+
+-------------------------------------------------------------------
 Wed Aug 30 20:16:10 UTC 2023 - Josef Reidinger <jreidinger@suse.cz>
 
 - 5.0.0 (bsc#1185510)

--- a/package/yast2-services-manager.spec
+++ b/package/yast2-services-manager.spec
@@ -24,7 +24,7 @@
 ######################################################################
 
 Name:           yast2-services-manager
-Version:        5.0.0
+Version:        5.0.1
 Release:        0
 Summary:        YaST2 - Services Manager
 Group:          System/YaST

--- a/src/lib/services-manager/services_manager_profile.rb
+++ b/src/lib/services-manager/services_manager_profile.rb
@@ -12,7 +12,6 @@ module Yast
   #     <enable config:type="list">
   #       <service>at</service>
   #       <service>cron</service>
-  #       <service>nscd</service>
   #       <service>openct</service>
   #       <service>postfix</service>
   #       <service>rsyslog</service>

--- a/src/modules/services_manager_target.rb
+++ b/src/modules/services_manager_target.rb
@@ -68,7 +68,6 @@ module Yast
     end
 
     # @return [Hash] Collection of available targets
-    # @example {'rescue' => {:enabled=>false, :loaded=>true, :active=>false, :description=>'Rescue'}}
     def targets
       read if @targets.nil?
       @targets

--- a/src/modules/services_manager_target.rb
+++ b/src/modules/services_manager_target.rb
@@ -68,6 +68,8 @@ module Yast
     end
 
     # @return [Hash] Collection of available targets
+    # @example Hash shape
+    #   {'rescue' => {:enabled=>false, :loaded=>true, :active=>false, :description=>'Rescue'}}
     def targets
       read if @targets.nil?
       @targets


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1236308


## Trello

https://trello.com/c/3Auiiwx8/


## Problem

`nscd` is now dropped from _Factory_ / _Tumbleweed_. YaST should not do any `nscd`-related actions anymore.

### GitHub Search

https://github.com/search?q=org%3Ayast+nscd+language%3APerl&type=code&l=Perl

https://github.com/search?q=org%3Ayast+nscd+language%3ARuby&type=code&l=Ruby


## Fix

Remove all code in sources and tests that refers to `nscd`, no matter if it's about the package, the system user account, or the user group, so future GitHub searches in YaST code will no longer get any hits for the `nscd` search term.

## Affected Branches / Products

Only _Factory_ / _Tumbleweed_.


## Related PRs

- https://github.com/yast/yast-users/pull/400
- https://github.com/yast/yast-apparmor/pull/64
- 